### PR TITLE
Fix test result publishing to github

### DIFF
--- a/.github/workflows/vm-perf-workflow.yml
+++ b/.github/workflows/vm-perf-workflow.yml
@@ -149,6 +149,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ inputs.REPO_REF }}
+          persist-credentials: false
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Purpose
Currently the step of publishing the perf results to github fails. This PR fixes it.

## Approach
Failure seems to be due to actions/checkout setting a credential in git config which takes precedence over the github bot token that we provide to write to github. This PR prevents that credential being persisted.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes