### PR TITLE
Add JMeter test for retrieving default OU ID and update execution ID handling

### DIFF
--- a/perf-scripts/common/jmeter/oauth/Thunder_OAuth_Authorization_Code_Grant.jmx
+++ b/perf-scripts/common/jmeter/oauth/Thunder_OAuth_Authorization_Code_Grant.jmx
@@ -202,6 +202,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
           <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+          <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
             <collectionProp name="Arguments.arguments">
               <elementProp name="client_id" elementType="HTTPArgument">
@@ -270,10 +271,10 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             <boolProp name="RegexExtractor.default_empty_value">false</boolProp>
           </RegexExtractor>
           <hashTree/>
-          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regex Extractor - flowId" enabled="true">
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regex Extractor - executionId" enabled="true">
             <stringProp name="RegexExtractor.useHeaders">true</stringProp>
-            <stringProp name="RegexExtractor.refname">flowId</stringProp>
-            <stringProp name="RegexExtractor.regex">[\?&amp;]flowId=([0-9a-fA-F\-]+)</stringProp>
+            <stringProp name="RegexExtractor.refname">executionId</stringProp>
+            <stringProp name="RegexExtractor.regex">[\?&amp;]executionId=([0-9a-fA-F\-]+)</stringProp>
             <stringProp name="RegexExtractor.template">$1$</stringProp>
             <stringProp name="RegexExtractor.default">FALSE</stringProp>
             <stringProp name="RegexExtractor.match_number">1</stringProp>
@@ -294,7 +295,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
               <elementProp name="" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
                 <stringProp name="Argument.value">{&#xd;
-	&quot;flowId&quot;:&quot;${flowId}&quot;,&#xd;
+	&quot;executionId&quot;:&quot;${executionId}&quot;,&#xd;
 	&quot;verbose&quot;:true&#xd;
 }</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
@@ -347,7 +348,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
                 <stringProp name="Argument.value">{&#xd;
 	&quot;action&quot;:&quot;action_001&quot;,&#xd;
-	&quot;flowId&quot;:&quot;${flowId}&quot;,&#xd;
+	&quot;executionId&quot;:&quot;${executionId}&quot;,&#xd;
 	&quot;inputs&quot;:{&#xd;
 		&quot;username&quot;:&quot;${username}&quot;,&#xd;
 		&quot;password&quot;:&quot;${password}&quot;&#xd;

--- a/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
+++ b/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
@@ -84,6 +84,62 @@
         </collectionProp>
       </Arguments>
       <hashTree/>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Get Default OU ID" enabled="true">
+        <intProp name="ThreadGroup.num_threads">1</intProp>
+        <intProp name="ThreadGroup.ramp_time">1</intProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
+          <stringProp name="LoopController.loops">1</stringProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+        </elementProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Get OU List" enabled="true">
+          <stringProp name="HTTPSampler.domain">${thunder_host}</stringProp>
+          <stringProp name="HTTPSampler.port">${thunder_port}</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">/organization-units</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="200 HTTP Code Response Assertion" enabled="true">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="49586">200</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.custom_message"></stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Extract default OU ID" enabled="true">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">import groovy.json.JsonSlurper
+
+def response = prev.getResponseDataAsString()
+def json = new JsonSlurper().parseText(response)
+
+def defaultOrg = json.organizationUnits.find { it.handle == &apos;default&apos; }
+
+if (defaultOrg) {
+    props.put(&apos;default_org_id&apos;, defaultOrg.id)
+} else {
+    props.put(&apos;default_org_id&apos;, &apos;NOT_FOUND&apos;)
+}</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+      </hashTree>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Create Application" enabled="true">
         <stringProp name="ThreadGroup.num_threads">${noOfThreads}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">${rampUpPeriod}</stringProp>
@@ -150,6 +206,7 @@ if (y == 0) {
               <elementProp name="" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">false</boolProp>
                 <stringProp name="Argument.value">{&#xd;
+    &quot;ouId&quot;: &quot;${__property(default_org_id)}&quot;,&#xd;
     &quot;name&quot;: &quot;${applicationNamePrefix}${application_count_id}&quot;,&#xd;
     &quot;description&quot;: &quot;Initial testing App&quot;,&#xd;
     &quot;inboundAuthConfig&quot;: [&#xd;
@@ -168,10 +225,7 @@ if (y == 0) {
                 &quot;responseTypes&quot;: [&#xd;
                     &quot;code&quot;&#xd;
                 ],&#xd;
-                &quot;tokenEndpointAuthMethods&quot;: [&#xd;
-                    &quot;client_secret_basic&quot;,&#xd;
-                    &quot;client_secret_post&quot;&#xd;
-                ]&#xd;
+                &quot;tokenEndpointAuthMethod&quot;: &quot;client_secret_basic&quot;&#xd;
             }&#xd;
         }&#xd;
     ]&#xd;


### PR DESCRIPTION
## Purpose
This pull request updates JMeter performance test scripts for Thunder OAuth and application setup, primarily to standardize on `executionId` instead of `flowId` and to improve test data initialization by dynamically retrieving the default organization unit (OU) ID. The changes also refine OAuth configuration payloads for greater clarity and accuracy.

**Thunder OAuth Script Updates:**

- Replaced all occurrences of `flowId` with `executionId` in regex extractors and HTTP request payloads to align with updated API expectations. [[1]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L273-R277) [[2]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L297-R298) [[3]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L350-R351)
- Updated the regex extractor's name and pattern to extract `executionId` instead of `flowId`.
- Set `HTTPSampler.follow_redirects` to `false` for relevant HTTP samplers to prevent automatic redirect following during OAuth flows.

**Test Data Initialization Improvements:**

- Added a new thread group (`Get Default OU ID`) to dynamically fetch the default organization unit ID at runtime. This includes an HTTP sampler to `/organization-units`, a response assertion for HTTP 200, and a Groovy post-processor to extract and store the default OU ID in a property.
- Updated the application creation payload to use the dynamically retrieved `${__property(default_org_id)}` as the `ouId` value, ensuring correct association with the default OU.

**OAuth Application Configuration Refinements:**

- Changed the application configuration to use a single `tokenEndpointAuthMethod` property (set to `"client_secret_basic"`) instead of an array of `tokenEndpointAuthMethods`, reflecting the expected API schema.