### PR TITLE
Refactor security variable naming in deployment scripts and configuration

### DIFF
--- a/kubernetes/azure/devops-pipelines/variables.yaml
+++ b/kubernetes/azure/devops-pipelines/variables.yaml
@@ -29,7 +29,7 @@ variables:
   THUNDER_KUBERNETES_INGRESS: "thunder-perf-ingress"
   THUNDER_HOSTNAME: "thunder.local"
   DATABASE_HOSTNAME: 'postgresql-thunder-perf-eastus2-001.postgres.database.azure.com'
-  THUNDER_SKIP_SECURITY: 'true'
+  SKIP_SECURITY: 'true'
 
   # Thunder Deployment Configuration
   THUNDER_REPLICAS: '2'

--- a/perf-scripts/common/deployment/setup/update-thunder-conf.sh
+++ b/perf-scripts/common/deployment/setup/update-thunder-conf.sh
@@ -116,7 +116,7 @@ echo "-------------------------------------------"
 cd "$carbon_home"
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 LOG_FILE="thunder_${TIMESTAMP}.log"
-THUNDER_SKIP_SECURITY=true bash start.sh > "$LOG_FILE" 2>&1 &
+SKIP_SECURITY=true bash start.sh > "$LOG_FILE" 2>&1 &
 cd "../"
 echo "Waiting 30s for Thunder server to start..."
 sleep 30s


### PR DESCRIPTION
## Purpose
This pull request updates the way the security skipping flag is set for Thunder deployments by standardizing the environment variable name from `THUNDER_SKIP_SECURITY` to `SKIP_SECURITY`. This ensures consistency across configuration and deployment scripts.

**Configuration variable renaming:**

* Renamed the `THUNDER_SKIP_SECURITY` variable to `SKIP_SECURITY` in `kubernetes/azure/devops-pipelines/variables.yaml` to standardize the environment variable name.

**Deployment script update:**

* Updated the `update-thunder-conf.sh` script to use `SKIP_SECURITY` instead of `THUNDER_SKIP_SECURITY` when starting Thunder, aligning it with the new variable name.