### PR TITLE
Improve VM perf tests

### DIFF
--- a/.github/scripts/create-cf-stack.sh
+++ b/.github/scripts/create-cf-stack.sh
@@ -23,9 +23,6 @@
 
 export AWS_DEFAULT_OUTPUT="json"
 
-# Defaults not exposed as workflow inputs
-BASTION_INSTANCE_TYPE="t3a.large"
-NGINX_INSTANCE_TYPE="t2.nano"
 DB_USERNAME="asgthunder"
 DB_PASSWORD="asgthunder"
 CERTIFICATE_NAME="is-perf-cert"

--- a/.github/workflows/vm-perf-workflow.yml
+++ b/.github/workflows/vm-perf-workflow.yml
@@ -36,6 +36,47 @@ on:
           - t3a.large
           - t3a.xlarge
           - t3a.2xlarge
+          - m8i.large
+          - m8i.xlarge
+          - m8i.2xlarge
+      NGINX_INSTANCE_TYPE:
+        description: 'Nginx VM instance type'
+        required: true
+        default: 't2.nano'
+        type: choice
+        options:
+          - t2.nano
+          - t2.micro
+          - t2.small
+          - t3a.nano
+          - t3a.micro
+          - t3a.small
+          - t3a.medium
+          - t3a.large
+          - t3a.xlarge
+          - t3a.2xlarge
+          - m8i.large
+          - m8i.xlarge
+          - m8i.2xlarge
+      BASTION_INSTANCE_TYPE:
+        description: 'Bastion VM instance type'
+        required: true
+        default: 't3a.large'
+        type: choice
+        options:
+          - t2.nano
+          - t2.micro
+          - t2.small
+          - t3a.nano
+          - t3a.micro
+          - t3a.small
+          - t3a.medium
+          - t3a.large
+          - t3a.xlarge
+          - t3a.2xlarge
+          - m8i.large
+          - m8i.xlarge
+          - m8i.2xlarge
       ADDITIONAL_PARAMS_TO_RUN_PERFORMANCE_SCRIPT:
         description: 'Additional parameters for performance script'
         required: true
@@ -89,6 +130,16 @@ on:
         description: 'Thunder VM instance type'
         required: false
         default: 't2.nano'
+        type: string
+      NGINX_INSTANCE_TYPE:
+        description: 'Nginx VM instance type'
+        required: false
+        default: 't2.nano'
+        type: string
+      BASTION_INSTANCE_TYPE:
+        description: 'Bastion VM instance type'
+        required: false
+        default: 't3a.large'
         type: string
       ADDITIONAL_PARAMS_TO_RUN_PERFORMANCE_SCRIPT:
         description: 'Additional parameters for performance script'
@@ -229,6 +280,8 @@ jobs:
           WORKSPACE: ${{ github.workspace }}
           DEPLOYMENT: ${{ inputs.DEPLOYMENT }}
           THUNDER_INSTANCE_TYPE: ${{ inputs.THUNDER_INSTANCE_TYPE }}
+          NGINX_INSTANCE_TYPE: ${{ inputs.NGINX_INSTANCE_TYPE }}
+          BASTION_INSTANCE_TYPE: ${{ inputs.BASTION_INSTANCE_TYPE }}
           DB_INSTANCE_TYPE: ${{ inputs.DB_INSTANCE_TYPE }}
           CONCURRENCY: ${{ inputs.CONCURRENCY }}
           DB_TYPE: 'postgres'

--- a/perf-scripts/common/jmeter/oauth/Thunder_OAuth_Authorization_Code_Grant.jmx
+++ b/perf-scripts/common/jmeter/oauth/Thunder_OAuth_Authorization_Code_Grant.jmx
@@ -57,7 +57,7 @@
         </collectionProp>
       </Arguments>
       <hashTree/>
-      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
         <collectionProp name="Arguments.arguments">
           <elementProp name="noOfThreads" elementType="Argument">
             <stringProp name="Argument.name">noOfThreads</stringProp>
@@ -99,6 +99,11 @@
           <elementProp name="noOfNodes" elementType="Argument">
             <stringProp name="Argument.name">noOfNodes</stringProp>
             <stringProp name="Argument.value">${__P(noOfNodes,1)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="useDelay" elementType="Argument">
+            <stringProp name="Argument.name">useDelay</stringProp>
+            <stringProp name="Argument.value">${__P(useDelay,true)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
         </collectionProp>
@@ -192,7 +197,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
           </collectionProp>
         </HeaderManager>
         <hashTree/>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="1 Send request to authorize endpoint">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="1 Send request to authorize endpoint" enabled="true">
           <stringProp name="HTTPSampler.domain">${thunder_host}</stringProp>
           <stringProp name="HTTPSampler.port">${thunder_port}</stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
@@ -238,7 +243,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
           <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion">
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 302 Response Assertion" enabled="true">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="103172738">HTTP/1.1 302</stringProp>
             </collectionProp>
@@ -248,7 +253,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             <stringProp name="Assertion.custom_message">Test failed - send request to authorize endpoint</stringProp>
           </ResponseAssertion>
           <hashTree/>
-          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regex Extractor - applicationId">
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regex Extractor - applicationId" enabled="true">
             <stringProp name="RegexExtractor.useHeaders">true</stringProp>
             <stringProp name="RegexExtractor.refname">applicationId</stringProp>
             <stringProp name="RegexExtractor.regex">[\?&amp;]applicationId=([0-9a-fA-F\-]+)</stringProp>
@@ -258,7 +263,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             <boolProp name="RegexExtractor.default_empty_value">false</boolProp>
           </RegexExtractor>
           <hashTree/>
-          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regex Extractor - authId">
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regex Extractor - authId" enabled="true">
             <stringProp name="RegexExtractor.useHeaders">true</stringProp>
             <stringProp name="RegexExtractor.refname">authId</stringProp>
             <stringProp name="RegexExtractor.regex">[\?&amp;]authId=([0-9a-fA-F\-]+)</stringProp>
@@ -268,7 +273,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             <boolProp name="RegexExtractor.default_empty_value">false</boolProp>
           </RegexExtractor>
           <hashTree/>
-          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regex Extractor - executionId">
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regex Extractor - executionId" enabled="true">
             <stringProp name="RegexExtractor.useHeaders">true</stringProp>
             <stringProp name="RegexExtractor.refname">executionId</stringProp>
             <stringProp name="RegexExtractor.regex">[\?&amp;]executionId=([0-9a-fA-F\-]+)</stringProp>
@@ -279,7 +284,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
           </RegexExtractor>
           <hashTree/>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="2 Start Authentication Flow">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="2 Start Authentication Flow" enabled="true">
           <stringProp name="HTTPSampler.domain">${thunder_host}</stringProp>
           <stringProp name="HTTPSampler.port">${thunder_port}</stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
@@ -302,7 +307,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
           <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 200 Response Assertion">
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 200 Response Assertion" enabled="true">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="103171775">HTTP/1.1 200</stringProp>
             </collectionProp>
@@ -312,7 +317,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             <stringProp name="Assertion.custom_message">Test failed - perform authnetication</stringProp>
           </ResponseAssertion>
           <hashTree/>
-          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="Next node assertion">
+          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="Next node assertion" enabled="true">
             <stringProp name="JSON_PATH">data.actions[0].nextNode</stringProp>
             <stringProp name="EXPECTED_VALUE">basic_auth</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
@@ -321,7 +326,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             <boolProp name="ISREGEX">false</boolProp>
           </JSONPathAssertion>
           <hashTree/>
-          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="Next action ref assertion">
+          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="Next action ref assertion" enabled="true">
             <stringProp name="JSON_PATH">data.actions[0].ref</stringProp>
             <stringProp name="EXPECTED_VALUE">action_001</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
@@ -330,7 +335,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             <boolProp name="ISREGEX">false</boolProp>
           </JSONPathAssertion>
           <hashTree/>
-          <JSONPostProcessor guiclass="JSONPostProcessorGui" testclass="JSONPostProcessor" testname="JSON Extractor - challengeToken">
+          <JSONPostProcessor guiclass="JSONPostProcessorGui" testclass="JSONPostProcessor" testname="JSON Extractor - challengeToken" enabled="true">
             <stringProp name="JSONPostProcessor.referenceNames">challengeToken</stringProp>
             <stringProp name="JSONPostProcessor.jsonPathExprs">challengeToken</stringProp>
             <stringProp name="JSONPostProcessor.match_numbers">1</stringProp>
@@ -338,7 +343,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
           </JSONPostProcessor>
           <hashTree/>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="3 Perform authentication">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="3 Perform authentication" enabled="true">
           <stringProp name="HTTPSampler.domain">${thunder_host}</stringProp>
           <stringProp name="HTTPSampler.port">${thunder_port}</stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
@@ -366,7 +371,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
           <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 200 Response Assertion">
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 200 Response Assertion" enabled="true">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="103171775">HTTP/1.1 200</stringProp>
             </collectionProp>
@@ -376,7 +381,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             <stringProp name="Assertion.custom_message">Test failed - perform authnetication</stringProp>
           </ResponseAssertion>
           <hashTree/>
-          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="Flow Status Complete Assertion">
+          <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="Flow Status Complete Assertion" enabled="true">
             <stringProp name="JSON_PATH">flowStatus</stringProp>
             <stringProp name="EXPECTED_VALUE">COMPLETE</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
@@ -385,15 +390,20 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             <boolProp name="ISREGEX">false</boolProp>
           </JSONPathAssertion>
           <hashTree/>
-          <JSONPostProcessor guiclass="JSONPostProcessorGui" testclass="JSONPostProcessor" testname="JSON Extractor - assertion">
+          <JSONPostProcessor guiclass="JSONPostProcessorGui" testclass="JSONPostProcessor" testname="JSON Extractor - assertion" enabled="true">
             <stringProp name="JSONPostProcessor.referenceNames">assertion</stringProp>
             <stringProp name="JSONPostProcessor.jsonPathExprs">assertion</stringProp>
             <stringProp name="JSONPostProcessor.match_numbers">1</stringProp>
             <stringProp name="JSONPostProcessor.defaultValues">FALSE</stringProp>
           </JSONPostProcessor>
           <hashTree/>
+          <GaussianRandomTimer guiclass="GaussianRandomTimerGui" testclass="GaussianRandomTimer" testname="Gaussian Random Timer" enabled="true">
+            <stringProp name="ConstantTimer.delay">${__groovy(&quot;${useDelay}&quot;.equals(&quot;true&quot;) ? 6000 : 0,)}</stringProp>
+            <stringProp name="RandomTimer.range">${__groovy(&quot;${useDelay}&quot;.equals(&quot;true&quot;) ? 2000 : 0,)} </stringProp>
+          </GaussianRandomTimer>
+          <hashTree/>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="4 Obtain authorization code">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="4 Obtain authorization code" enabled="true">
           <stringProp name="HTTPSampler.domain">${thunder_host}</stringProp>
           <stringProp name="HTTPSampler.port">${thunder_port}</stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
@@ -416,7 +426,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
           <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
         </HTTPSamplerProxy>
         <hashTree>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 200 Response Assertion">
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="HTTP/1.1 200 Response Assertion" enabled="true">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="103171775">HTTP/1.1 200</stringProp>
             </collectionProp>
@@ -426,7 +436,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             <stringProp name="Assertion.custom_message">Test failed - obtain authorization code</stringProp>
           </ResponseAssertion>
           <hashTree/>
-          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regex Extractor - code">
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regex Extractor - code" enabled="true">
             <stringProp name="RegexExtractor.useHeaders">false</stringProp>
             <stringProp name="RegexExtractor.refname">code</stringProp>
             <stringProp name="RegexExtractor.regex">[\?&amp;]code=([A-Za-z0-9._~-]+)</stringProp>
@@ -437,7 +447,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
           </RegexExtractor>
           <hashTree/>
         </hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="5 Obtain access token">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="5 Obtain access token" enabled="true">
           <stringProp name="HTTPSampler.domain">${thunder_host}</stringProp>
           <stringProp name="HTTPSampler.port">${thunder_port}</stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>

--- a/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
+++ b/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
@@ -6,7 +6,6 @@
       <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables">
         <collectionProp name="Arguments.arguments"/>
       </elementProp>
-      <boolProp name="TestPlan.functional_mode">false</boolProp>
     </TestPlan>
     <hashTree>
       <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="Server Variables">
@@ -84,7 +83,7 @@
         </collectionProp>
       </Arguments>
       <hashTree/>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Get Default OU ID" enabled="true">
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Create Custom Authn Flow">
         <intProp name="ThreadGroup.num_threads">1</intProp>
         <intProp name="ThreadGroup.ramp_time">1</intProp>
         <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
@@ -95,7 +94,191 @@
         </elementProp>
       </ThreadGroup>
       <hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Get OU List" enabled="true">
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Create Authn Flow">
+          <stringProp name="HTTPSampler.domain">${thunder_host}</stringProp>
+          <stringProp name="HTTPSampler.port">${thunder_port}</stringProp>
+          <stringProp name="HTTPSampler.protocol">https</stringProp>
+          <stringProp name="HTTPSampler.path">/flows</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&#xd;
+    &quot;handle&quot;: &quot;custom-basic-flow&quot;,&#xd;
+    &quot;name&quot;: &quot;Custom Basic Authentication Flow&quot;,&#xd;
+    &quot;flowType&quot;: &quot;AUTHENTICATION&quot;,&#xd;
+    &quot;nodes&quot;: [&#xd;
+        {&#xd;
+            &quot;id&quot;: &quot;start&quot;,&#xd;
+            &quot;type&quot;: &quot;START&quot;,&#xd;
+            &quot;onSuccess&quot;: &quot;prompt_credentials&quot;&#xd;
+        },&#xd;
+        {&#xd;
+            &quot;id&quot;: &quot;prompt_credentials&quot;,&#xd;
+            &quot;type&quot;: &quot;PROMPT&quot;,&#xd;
+            &quot;meta&quot;: {&#xd;
+                &quot;components&quot;: [&#xd;
+                    {&#xd;
+                        &quot;alt&quot;: &quot;{{ t(signin:images.app_logo.alt) }}&quot;,&#xd;
+                        &quot;category&quot;: &quot;DISPLAY&quot;,&#xd;
+                        &quot;height&quot;: &quot;60&quot;,&#xd;
+                        &quot;id&quot;: &quot;image&quot;,&#xd;
+                        &quot;resourceType&quot;: &quot;ELEMENT&quot;,&#xd;
+                        &quot;src&quot;: &quot;{{ meta(application.logoUrl) }}&quot;,&#xd;
+                        &quot;type&quot;: &quot;IMAGE&quot;,&#xd;
+                        &quot;width&quot;: &quot;&quot;&#xd;
+                    },&#xd;
+                    {&#xd;
+                        &quot;align&quot;: &quot;center&quot;,&#xd;
+                        &quot;id&quot;: &quot;text_001&quot;,&#xd;
+                        &quot;label&quot;: &quot;{{ t(signin:forms.credentials.title) }}&quot;,&#xd;
+                        &quot;type&quot;: &quot;TEXT&quot;,&#xd;
+                        &quot;variant&quot;: &quot;HEADING_1&quot;&#xd;
+                    },&#xd;
+                    {&#xd;
+                        &quot;components&quot;: [&#xd;
+                            {&#xd;
+                                &quot;id&quot;: &quot;input_001&quot;,&#xd;
+                                &quot;label&quot;: &quot;{{ t(signin:forms.credentials.fields.username.label) }}&quot;,&#xd;
+                                &quot;placeholder&quot;: &quot;{{ t(signin:forms.credentials.fields.username.placeholder) }}&quot;,&#xd;
+                                &quot;ref&quot;: &quot;username&quot;,&#xd;
+                                &quot;required&quot;: true,&#xd;
+                                &quot;type&quot;: &quot;TEXT_INPUT&quot;&#xd;
+                            },&#xd;
+                            {&#xd;
+                                &quot;id&quot;: &quot;input_002&quot;,&#xd;
+                                &quot;label&quot;: &quot;{{ t(signin:forms.credentials.fields.password.label) }}&quot;,&#xd;
+                                &quot;placeholder&quot;: &quot;{{ t(signin:forms.credentials.fields.password.placeholder) }}&quot;,&#xd;
+                                &quot;ref&quot;: &quot;password&quot;,&#xd;
+                                &quot;required&quot;: true,&#xd;
+                                &quot;type&quot;: &quot;PASSWORD_INPUT&quot;&#xd;
+                            },&#xd;
+                            {&#xd;
+                                &quot;category&quot;: &quot;DISPLAY&quot;,&#xd;
+                                &quot;id&quot;: &quot;rich_text_forgot_password&quot;,&#xd;
+                                &quot;label&quot;: &quot;&lt;p class=\&quot;rich-text-paragraph\&quot;&gt;&lt;span class=\&quot;rich-text-pre-wrap\&quot;&gt;{{ t(signin:forms.credentials.links.forgot_password.prefix) }} &lt;/span&gt;&lt;a href=\&quot;{{meta(application.forgot_password_url)}}\&quot; target=\&quot;_blank\&quot; rel=\&quot;noopener noreferrer\&quot; class=\&quot;rich-text-link\&quot;&gt;&lt;span class=\&quot;rich-text-pre-wrap\&quot;&gt;{{ t(signin:forms.credentials.links.forgot_password.label) }}&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&quot;,&#xd;
+                                &quot;resourceType&quot;: &quot;ELEMENT&quot;,&#xd;
+                                &quot;type&quot;: &quot;RICH_TEXT&quot;&#xd;
+                            },&#xd;
+                            {&#xd;
+                                &quot;eventType&quot;: &quot;SUBMIT&quot;,&#xd;
+                                &quot;id&quot;: &quot;action_001&quot;,&#xd;
+                                &quot;label&quot;: &quot;{{ t(signin:forms.credentials.actions.submit.label) }}&quot;,&#xd;
+                                &quot;type&quot;: &quot;ACTION&quot;,&#xd;
+                                &quot;variant&quot;: &quot;PRIMARY&quot;&#xd;
+                            },&#xd;
+                            {&#xd;
+                                &quot;category&quot;: &quot;DISPLAY&quot;,&#xd;
+                                &quot;id&quot;: &quot;rich_text_signup&quot;,&#xd;
+                                &quot;label&quot;: &quot;&lt;p class=\&quot;rich-text-paragraph\&quot;&gt;&lt;span class=\&quot;rich-text-pre-wrap\&quot;&gt;{{ t(signin:forms.credentials.links.sign_up.prefix) }} &lt;/span&gt;&lt;a href=\&quot;{{meta(application.sign_up_url)}}\&quot; target=\&quot;_blank\&quot; rel=\&quot;noopener noreferrer\&quot; class=\&quot;rich-text-link\&quot;&gt;&lt;span class=\&quot;rich-text-pre-wrap\&quot;&gt;{{ t(signin:forms.credentials.links.sign_up.label) }}&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&quot;,&#xd;
+                                &quot;resourceType&quot;: &quot;ELEMENT&quot;,&#xd;
+                                &quot;type&quot;: &quot;RICH_TEXT&quot;&#xd;
+                            }&#xd;
+                        ],&#xd;
+                        &quot;id&quot;: &quot;block_001&quot;,&#xd;
+                        &quot;type&quot;: &quot;BLOCK&quot;&#xd;
+                    }&#xd;
+                ]&#xd;
+            },&#xd;
+            &quot;prompts&quot;: [&#xd;
+                {&#xd;
+                    &quot;inputs&quot;: [&#xd;
+                        {&#xd;
+                            &quot;ref&quot;: &quot;input_001&quot;,&#xd;
+                            &quot;type&quot;: &quot;TEXT_INPUT&quot;,&#xd;
+                            &quot;identifier&quot;: &quot;username&quot;,&#xd;
+                            &quot;required&quot;: true&#xd;
+                        },&#xd;
+                        {&#xd;
+                            &quot;ref&quot;: &quot;input_002&quot;,&#xd;
+                            &quot;type&quot;: &quot;PASSWORD_INPUT&quot;,&#xd;
+                            &quot;identifier&quot;: &quot;password&quot;,&#xd;
+                            &quot;required&quot;: true&#xd;
+                        }&#xd;
+                    ],&#xd;
+                    &quot;action&quot;: {&#xd;
+                        &quot;ref&quot;: &quot;action_001&quot;,&#xd;
+                        &quot;nextNode&quot;: &quot;basic_auth&quot;&#xd;
+                    }&#xd;
+                }&#xd;
+            ]&#xd;
+        },&#xd;
+        {&#xd;
+            &quot;id&quot;: &quot;basic_auth&quot;,&#xd;
+            &quot;type&quot;: &quot;TASK_EXECUTION&quot;,&#xd;
+            &quot;executor&quot;: {&#xd;
+                &quot;name&quot;: &quot;BasicAuthExecutor&quot;&#xd;
+            },&#xd;
+            &quot;onSuccess&quot;: &quot;auth_assert&quot;,&#xd;
+            &quot;onIncomplete&quot;: &quot;prompt_credentials&quot;&#xd;
+        },&#xd;
+        {&#xd;
+            &quot;id&quot;: &quot;auth_assert&quot;,&#xd;
+            &quot;type&quot;: &quot;TASK_EXECUTION&quot;,&#xd;
+            &quot;executor&quot;: {&#xd;
+                &quot;name&quot;: &quot;AuthAssertExecutor&quot;&#xd;
+            },&#xd;
+            &quot;onSuccess&quot;: &quot;end&quot;&#xd;
+        },&#xd;
+        {&#xd;
+            &quot;id&quot;: &quot;end&quot;,&#xd;
+            &quot;type&quot;: &quot;END&quot;&#xd;
+        }&#xd;
+    ]&#xd;
+}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="201 HTTP Code Response Assertion">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="49587">201</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">2</intProp>
+            <stringProp name="Assertion.custom_message"></stringProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Extract custom authn flow ID">
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="script">import groovy.json.JsonSlurper
+
+def response = prev.getResponseDataAsString()
+def json = new JsonSlurper().parseText(response)
+
+def flowId = json.id
+
+if (flowId) {
+    props.put(&apos;custom_flow_id&apos;, flowId)
+} else {
+    props.put(&apos;custom_flow_id&apos;, &apos;NOT_FOUND&apos;)
+}</stringProp>
+            <stringProp name="scriptLanguage">groovy</stringProp>
+          </JSR223PostProcessor>
+          <hashTree/>
+        </hashTree>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Get Default OU ID">
+        <intProp name="ThreadGroup.num_threads">1</intProp>
+        <intProp name="ThreadGroup.ramp_time">1</intProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller">
+          <stringProp name="LoopController.loops">1</stringProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+        </elementProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Get OU List">
           <stringProp name="HTTPSampler.domain">${thunder_host}</stringProp>
           <stringProp name="HTTPSampler.port">${thunder_port}</stringProp>
           <stringProp name="HTTPSampler.protocol">https</stringProp>
@@ -109,7 +292,7 @@
           </elementProp>
         </HTTPSamplerProxy>
         <hashTree>
-          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="200 HTTP Code Response Assertion" enabled="true">
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="200 HTTP Code Response Assertion">
             <collectionProp name="Asserion.test_strings">
               <stringProp name="49586">200</stringProp>
             </collectionProp>
@@ -119,7 +302,7 @@
             <stringProp name="Assertion.custom_message"></stringProp>
           </ResponseAssertion>
           <hashTree/>
-          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Extract default OU ID" enabled="true">
+          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="Extract default OU ID">
             <stringProp name="cacheKey">true</stringProp>
             <stringProp name="filename"></stringProp>
             <stringProp name="parameters"></stringProp>
@@ -209,6 +392,7 @@ if (y == 0) {
     &quot;ouId&quot;: &quot;${__property(default_org_id)}&quot;,&#xd;
     &quot;name&quot;: &quot;${applicationNamePrefix}${application_count_id}&quot;,&#xd;
     &quot;description&quot;: &quot;Initial testing App&quot;,&#xd;
+    &quot;authFlowId&quot;: &quot;${__property(custom_flow_id)}&quot;,&#xd;
     &quot;inboundAuthConfig&quot;: [&#xd;
         {&#xd;
             &quot;type&quot;: &quot;oauth2&quot;,&#xd;

--- a/perf-scripts/single-node/setup/resources/deployment.yaml
+++ b/perf-scripts/single-node/setup/resources/deployment.yaml
@@ -40,6 +40,9 @@ database:
           username: "asgthunder"
           password: "asgthunder"
           sslmode: "disable"
+          max_open_conns: 20
+          max_idle_conns: 20
+          conn_max_lifetime: 300
     runtime:
         type: "postgres"
         postgres:
@@ -49,6 +52,9 @@ database:
           username: "asgthunder"
           password: "asgthunder"
           sslmode: "disable"
+          max_open_conns: 20
+          max_idle_conns: 20
+          conn_max_lifetime: 300
     user:
         type: "postgres"
         postgres:
@@ -58,6 +64,9 @@ database:
           username: "asgthunder"
           password: "asgthunder"
           sslmode: "disable"
+          max_open_conns: 20
+          max_idle_conns: 20
+          conn_max_lifetime: 300
 
 cache:
   disabled: false

--- a/perf-scripts/single-node/setup/resources/deployment.yaml
+++ b/perf-scripts/single-node/setup/resources/deployment.yaml
@@ -77,9 +77,6 @@ cache:
 jwt:
   issuer: "thunder"
 
-
 crypto:
   password_hashing:
-    algorithm: "PBKDF2"
-    pbkdf2:
-      iterations: 10000
+    algorithm: "SHA256"

--- a/perf-scripts/single-node/single-node.yaml
+++ b/perf-scripts/single-node/single-node.yaml
@@ -206,6 +206,9 @@ Resources:
       MasterUsername: !Ref DBUsername
       MasterUserPassword: !Ref DBPassword
       MultiAZ: 'false'
+      AvailabilityZone: !Select
+        - '0'
+        - !GetAZs ''
       Iops: !FindInMap [HighConcurrencyModeMap, !Ref EnableHighConcurrencyMode, DBIops]
       StorageType: io1
       DBParameterGroupName: !FindInMap [DBTypeMap, !Ref DBType, ParameterGroup]

--- a/perf-scripts/single-node/single-node.yaml
+++ b/perf-scripts/single-node/single-node.yaml
@@ -582,6 +582,9 @@ Parameters:
       - t3a.large
       - t3a.xlarge
       - t3a.2xlarge
+      - m8i.large
+      - m8i.xlarge
+      - m8i.2xlarge
     ConstraintDescription: Must be a valid EC2 instance type
   NginxInstanceType:
     Type: String
@@ -597,6 +600,9 @@ Parameters:
       - t3a.large
       - t3a.xlarge
       - t3a.2xlarge
+      - m8i.large
+      - m8i.xlarge
+      - m8i.2xlarge
     ConstraintDescription: Must be a valid EC2 instance type
   DBUsername:
     Type: String
@@ -643,6 +649,11 @@ Parameters:
       - t3a.small
       - t3a.medium
       - t3a.large
+      - t3a.xlarge
+      - t3a.2xlarge
+      - m8i.large
+      - m8i.xlarge
+      - m8i.2xlarge
       - t3a.xlarge
       - t3a.2xlarge
     ConstraintDescription: Must be a valid EC2 instance type


### PR DESCRIPTION
## Purpose

This pull request introduces several enhancements and configuration improvements to both the performance workflow and the JMeter OAuth test plan. The main changes include making the VM instance types for Bastion and Nginx configurable in the workflow, expanding the available instance type options, and improving the flexibility and reliability of the JMeter test by enabling/disabling components and adding configurable delays. Additionally, database connection pooling parameters have been added to the deployment configuration for better resource management.

**Workflow and Infrastructure Configuration:**

* Made `BASTION_INSTANCE_TYPE` and `NGINX_INSTANCE_TYPE` configurable as workflow inputs, expanded their selectable options to include new instance types (e.g., `m8i.large` series), and set sensible defaults. These values are now passed as environment variables to jobs. (`.github/workflows/vm-perf-workflow.yml`, `.github/scripts/create-cf-stack.sh`) [[1]](diffhunk://#diff-dfde076b477b579f9ce345906c0e953bc6580b3db1207782e3fd7ae3cccf8c3eR39-R79) [[2]](diffhunk://#diff-dfde076b477b579f9ce345906c0e953bc6580b3db1207782e3fd7ae3cccf8c3eR134-R143) [[3]](diffhunk://#diff-dfde076b477b579f9ce345906c0e953bc6580b3db1207782e3fd7ae3cccf8c3eR283-R284) [[4]](diffhunk://#diff-40c05635ddc7dc087ee3338181b9d98293d69dc3e75284c55c2ca633df04c6b3L26-L28)

**JMeter Test Plan Improvements:**

* Enabled all critical samplers, assertions, and extractors in the `Thunder_OAuth_Authorization_Code_Grant.jmx` test plan to ensure all steps are executed and validated during performance testing. [[1]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L195-R200) [[2]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L241-R246) [[3]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L251-R256) [[4]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L261-R266) [[5]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L271-R276) [[6]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L282-R287) [[7]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L305-R310) [[8]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L315-R320) [[9]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L324-R329) [[10]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L333-R346) [[11]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L369-R374) [[12]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L379-R384) [[13]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L388-R406) [[14]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L419-R429) [[15]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L429-R439) [[16]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L440-R450)

* Added a `useDelay` variable and a `GaussianRandomTimer` to allow optional delays between authentication steps, making the load test more realistic and configurable. [[1]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80R104-R108) [[2]](diffhunk://#diff-3e7bd28b51afbcbe9beb75795aca756009e3ca697b7d1127d5487f6b36a73c80L388-R406)

**Database Configuration Enhancements:**

* Introduced database connection pooling parameters (`max_open_conns`, `max_idle_conns`, `conn_max_lifetime`) in `deployment.yaml` for both `database` and `user` configurations, improving database resource management under load. [[1]](diffhunk://#diff-353a4162fe191ada88f457213227142644b053bebbb243a50f77de3bd0edb5d3R43-R45) [[2]](diffhunk://#diff-353a4162fe191ada88f457213227142644b053bebbb243a50f77de3bd0edb5d3R55-R57)

