### PR TITLE
Update heap sizes and jvm args

### DIFF
--- a/perf-scripts/common/jmeter/perf-test-pre-provisioned.sh
+++ b/perf-scripts/common/jmeter/perf-test-pre-provisioned.sh
@@ -62,7 +62,7 @@ test_duration=$default_test_duration
 default_warm_up_time=5
 warm_up_time=$default_warm_up_time
 # Heap size of JMeter Client
-default_jmeter_client_heap_size=8G
+default_jmeter_client_heap_size=32G
 jmeter_client_heap_size=$default_jmeter_client_heap_size
 
 # Scenario names to include
@@ -529,7 +529,7 @@ function test_scenarios() {
 
             before_execute_test_scenario
 
-            export JVM_ARGS="-server -Xms$jmeter_client_heap_size -Xmx$jmeter_client_heap_size -Xlog:gc:$report_location/jmeter_gc.log $JMETER_JVM_ARGS"
+            export JVM_ARGS="-server -Xms$jmeter_client_heap_size -Xmx$jmeter_client_heap_size -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc:$report_location/jmeter_gc.log $JMETER_JVM_ARGS"
 
             local jmeter_command="jmeter -n -t $script_dir/$jmx_file"
             for param in "${jmeter_params[@]}"; do

--- a/perf-scripts/common/jmeter/perf-test-thunder.sh
+++ b/perf-scripts/common/jmeter/perf-test-thunder.sh
@@ -61,7 +61,7 @@ test_duration=$default_test_duration
 default_warm_up_time=5
 warm_up_time=$default_warm_up_time
 # Heap size of JMeter Client
-default_jmeter_client_heap_size=8G
+default_jmeter_client_heap_size=32G
 jmeter_client_heap_size=$default_jmeter_client_heap_size
 
 # Scenario names to include
@@ -581,7 +581,7 @@ function test_scenarios() {
 
             before_execute_test_scenario "$db_type"
 
-            export JVM_ARGS="-Xms$jmeter_client_heap_size -Xmx$jmeter_client_heap_size -Xlog:gc:$report_location/jmeter_gc.log $JMETER_JVM_ARGS"
+            export JVM_ARGS="-Xms$jmeter_client_heap_size -Xmx$jmeter_client_heap_size -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc:$report_location/jmeter_gc.log $JMETER_JVM_ARGS"
 
             local jmeter_command="jmeter -n -t $script_dir/$jmx_file"
             for param in "${jmeter_params[@]}"; do


### PR DESCRIPTION
## Purpose
This pull request updates the JMeter performance test scripts to improve JVM memory allocation and garbage collection settings, aiming for better performance and stability during large-scale tests. The most important changes are:

**JVM Heap Size Increase:**

* Increased the default JMeter client heap size from `8G` to `32G` in both `perf-test-pre-provisioned.sh` and `perf-test-thunder.sh`, allowing the scripts to handle more intensive workloads. [[1]](diffhunk://#diff-26533e1df5f82b4cc32796b82a088969857e7c45c635aaf131740a8c84ee4b73L65-R65) [[2]](diffhunk://#diff-be7fad778bd74562bc74e4c31d1d79ad646a07f63053c94557eefba058d9a02aL64-R64)

**Garbage Collection Configuration:**

* Updated the `JVM_ARGS` in both scripts to use the G1 Garbage Collector (`-XX:+UseG1GC`) and set a maximum GC pause time (`-XX:MaxGCPauseMillis=200`), which should reduce GC pause times and improve overall test consistency. [[1]](diffhunk://#diff-26533e1df5f82b4cc32796b82a088969857e7c45c635aaf131740a8c84ee4b73L532-R532) [[2]](diffhunk://#diff-be7fad778bd74562bc74e4c31d1d79ad646a07f63053c94557eefba058d9a02aL584-R584)