### PR TITLE
Update redis onboarding and perf templates

### DIFF
--- a/kubernetes/azure/devops-pipelines/deploy-thunder.yaml
+++ b/kubernetes/azure/devops-pipelines/deploy-thunder.yaml
@@ -27,15 +27,12 @@ parameters:
     displayName: Create Nginx TLS Secret
     type: boolean
     default: true
-  - name: CLEANUP_DB
-    displayName: Cleanup Database(s) Before Setup
-    type: boolean
-    default: false
   - name: CLEANUP_TARGET
-    displayName: Cleanup Target DB
+    displayName: Cleanup Database(s) Before Setup
     type: string
-    default: 'all'
+    default: 'none'
     values:
+      - none
       - all
       - runtime
       - user
@@ -59,29 +56,22 @@ parameters:
     values:
       - postgres
       - redis
-  - name: CACHE_ENABLED
-    displayName: Enable Cache
-    type: boolean
-    default: false
-  - name: CACHE_TYPE
-    displayName: Cache Type
+  - name: CACHE_MODE
+    displayName: Cache Mode
     type: string
-    default: 'redis'
+    default: 'disabled'
     values:
+      - disabled
       - in-memory
       - redis
   - name: POPULATE_TEST_DATA
     displayName: Populate Test Data
     type: boolean
     default: true
-  - name: SEED_USERS
-    displayName: Seed Test Users into User DB
-    type: boolean
-    default: false
   - name: SEED_USERS_COUNT
-    displayName: Number of users to seed
+    displayName: Seed Users Count (0 to skip)
     type: number
-    default: 50000000
+    default: 0
   - name: THUNDER_REPO
     type: string
     displayName: "Thunder Repository"
@@ -160,7 +150,7 @@ jobs:
 
   - job: cleanup_db
     displayName: Cleanup Database(s)
-    condition: eq('${{ parameters.CLEANUP_DB }}', true)
+    condition: ne('${{ parameters.CLEANUP_TARGET }}', 'none')
     steps:
       - template: './templates/cleanup-db.yaml'
         parameters:
@@ -178,8 +168,8 @@ jobs:
           WORKING_DIRECTORY: $(Agent.BuildDirectory)/thunder-repo/backend
 
   - job: install_redis
-    displayName: Install Redis Cache
-    condition: and(eq('${{ parameters.CACHE_ENABLED }}', true), eq('${{ parameters.CACHE_TYPE }}', 'redis'))
+    displayName: Install Redis
+    condition: or(eq('${{ parameters.CACHE_MODE }}', 'redis'), eq('${{ parameters.RUNTIME_DB_TYPE }}', 'redis'))
     steps:
       - checkout: self
       - template: './templates/install-redis.yaml'
@@ -205,8 +195,7 @@ jobs:
           THUNDER_IMAGE_REPOSITORY: ${{ parameters.THUNDER_IMAGE_REPOSITORY }}
           THUNDER_IMAGE_TAG: ${{ parameters.THUNDER_IMAGE_TAG }}
           SKIP_SECURITY: 'true'
-          CACHE_ENABLED: ${{ parameters.CACHE_ENABLED }}
-          CACHE_TYPE: ${{ parameters.CACHE_TYPE }}
+          CACHE_MODE: ${{ parameters.CACHE_MODE }}
 
   - job: add_hosts_entry_to_vm
     displayName: Add Hosts Entry to VM
@@ -236,7 +225,7 @@ jobs:
     dependsOn:
       - install_thunder
       - setup_db_schema
-    condition: eq('${{ parameters.SEED_USERS }}', true)
+    condition: ne(${{ parameters.SEED_USERS_COUNT }}, 0)
     steps:
       - checkout: thunder-performance
         path: "thunder-performance"

--- a/kubernetes/azure/devops-pipelines/perf-test-execution.yaml
+++ b/kubernetes/azure/devops-pipelines/perf-test-execution.yaml
@@ -109,15 +109,12 @@ parameters:
     values:
       - postgres
       - redis
-  - name: CACHE_ENABLED
-    displayName: Enable Cache
-    type: boolean
-    default: false
-  - name: CACHE_TYPE
-    displayName: Cache Type
+  - name: CACHE_MODE
+    displayName: Cache Mode
     type: string
-    default: 'redis'
+    default: 'disabled'
     values:
+      - disabled
       - in-memory
       - redis
   - name: BUILD_PURPOSE
@@ -154,11 +151,6 @@ variables:
       value: 'false'
   - name: RUNTIME_DB_TYPE
     value: ${{parameters.RUNTIME_DB_TYPE}}
-  - name: CACHE_ENABLED
-    ${{ if eq(parameters.CACHE_ENABLED, true) }}:
-      value: 'true'
-    ${{ else }}:
-      value: 'false'
   - name: PYTHON_VERSION
     value: 3.9
 
@@ -229,9 +221,9 @@ jobs:
             echo "Postgres Server started successfully"
 
   - job: install_redis
-    displayName: Install Redis Cache
+    displayName: Install Redis
     dependsOn: scale_up_env
-    condition: and(always(), eq(${{ parameters.CACHE_ENABLED }}, True), eq('${{ parameters.CACHE_TYPE }}', 'redis'))
+    condition: and(always(), or(eq('${{ parameters.CACHE_MODE }}', 'redis'), eq('${{ parameters.RUNTIME_DB_TYPE }}', 'redis')))
     steps:
       - checkout: self
       - template: './templates/install-redis.yaml'
@@ -256,8 +248,7 @@ jobs:
           THUNDER_IMAGE_REGISTRY: ${{ parameters.THUNDER_IMAGE_REGISTRY }}
           THUNDER_IMAGE_REPOSITORY: ${{ parameters.THUNDER_IMAGE_REPOSITORY }}
           THUNDER_IMAGE_TAG: ${{ parameters.THUNDER_IMAGE_TAG }}
-          CACHE_ENABLED: ${{ parameters.CACHE_ENABLED }}
-          CACHE_TYPE: ${{ parameters.CACHE_TYPE }}
+          CACHE_MODE: ${{ parameters.CACHE_MODE }}
 
   - job: thunder_performance_test
     displayName: Thunder performance test

--- a/kubernetes/azure/devops-pipelines/templates/install-redis.yaml
+++ b/kubernetes/azure/devops-pipelines/templates/install-redis.yaml
@@ -41,34 +41,38 @@ steps:
         echo "Creating namespace ${{ parameters.NAMESPACE }} if it does not exist"
         kubectl create namespace ${{ parameters.NAMESPACE }} --dry-run=client -o yaml | kubectl apply -f -
 
-        echo "Adding Bitnami Helm repository"
-        helm repo add bitnami https://charts.bitnami.com/bitnami
-        helm repo update
+        if helm list -n ${{ parameters.NAMESPACE }} -q --filter "^${{ parameters.RELEASE_NAME }}$" | grep -q "^${{ parameters.RELEASE_NAME }}$"; then
+          echo "Redis release ${{ parameters.RELEASE_NAME }} already exists. Skipping installation to preserve existing data."
+        else
+          echo "Adding Bitnami Helm repository"
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo update
 
-        echo "Installing Redis Helm Chart"
-        helm upgrade --install ${{ parameters.RELEASE_NAME }} bitnami/redis \
-          --namespace ${{ parameters.NAMESPACE }} \
-          --values kubernetes/azure/devops-pipelines/templates/redis-values.yaml \
-          --set auth.password=${{ parameters.REDIS_PASSWORD }} \
-          --set architecture=replication \
-          --set master.persistence.enabled=false \
-          --set replica.persistence.enabled=false \
-          --set master.resources.requests.cpu=$(REDIS_CPU_REQUESTS) \
-          --set master.resources.requests.memory=$(REDIS_MEMORY_REQUESTS) \
-          --set master.resources.limits.cpu=$(REDIS_CPU_LIMITS) \
-          --set master.resources.limits.memory=$(REDIS_MEMORY_LIMITS) \
-          --set replica.resources.requests.cpu=$(REDIS_REPLICA_CPU_REQUESTS) \
-          --set replica.resources.requests.memory=$(REDIS_REPLICA_MEMORY_REQUESTS) \
-          --set replica.resources.limits.cpu=$(REDIS_REPLICA_CPU_LIMITS) \
-          --set replica.resources.limits.memory=$(REDIS_REPLICA_MEMORY_LIMITS) \
-          --set replica.autoscaling.enabled=true \
-          --set replica.autoscaling.minReplicas=$(REDIS_REPLICA_HPA_MIN_REPLICAS) \
-          --set replica.autoscaling.maxReplicas=$(REDIS_REPLICA_HPA_MAX_REPLICAS) \
-          --set replica.autoscaling.targetCPU=$(REDIS_REPLICA_HPA_CPU_UTILIZATION) \
-          --set replica.autoscaling.targetMemory=$(REDIS_REPLICA_HPA_MEMORY_UTILIZATION) \
-          --wait --timeout 5m
-        echo "Redis Helm Chart installed successfully"
-        echo "Redis is accessible at: ${{ parameters.RELEASE_NAME }}-master.${{ parameters.NAMESPACE }}.svc.cluster.local:6379"
+          echo "Installing Redis Helm Chart"
+          helm upgrade --install ${{ parameters.RELEASE_NAME }} bitnami/redis \
+            --namespace ${{ parameters.NAMESPACE }} \
+            --values kubernetes/azure/devops-pipelines/templates/redis-values.yaml \
+            --set auth.password=${{ parameters.REDIS_PASSWORD }} \
+            --set architecture=replication \
+            --set master.persistence.enabled=false \
+            --set replica.persistence.enabled=false \
+            --set master.resources.requests.cpu=$(REDIS_CPU_REQUESTS) \
+            --set master.resources.requests.memory=$(REDIS_MEMORY_REQUESTS) \
+            --set master.resources.limits.cpu=$(REDIS_CPU_LIMITS) \
+            --set master.resources.limits.memory=$(REDIS_MEMORY_LIMITS) \
+            --set replica.resources.requests.cpu=$(REDIS_REPLICA_CPU_REQUESTS) \
+            --set replica.resources.requests.memory=$(REDIS_REPLICA_MEMORY_REQUESTS) \
+            --set replica.resources.limits.cpu=$(REDIS_REPLICA_CPU_LIMITS) \
+            --set replica.resources.limits.memory=$(REDIS_REPLICA_MEMORY_LIMITS) \
+            --set replica.autoscaling.enabled=true \
+            --set replica.autoscaling.minReplicas=$(REDIS_REPLICA_HPA_MIN_REPLICAS) \
+            --set replica.autoscaling.maxReplicas=$(REDIS_REPLICA_HPA_MAX_REPLICAS) \
+            --set replica.autoscaling.targetCPU=$(REDIS_REPLICA_HPA_CPU_UTILIZATION) \
+            --set replica.autoscaling.targetMemory=$(REDIS_REPLICA_HPA_MEMORY_UTILIZATION) \
+            --wait --timeout 5m
+          echo "Redis Helm Chart installed successfully"
+          echo "Redis is accessible at: ${{ parameters.RELEASE_NAME }}-master.${{ parameters.NAMESPACE }}.svc.cluster.local:6379"
+        fi
 
         echo "Applying NetworkPolicy to allow ingress from Thunder (default namespace) to Redis"
         kubectl apply -f kubernetes/azure/devops-pipelines/templates/redis-network-policy.yaml

--- a/kubernetes/azure/devops-pipelines/templates/install-thunder.yaml
+++ b/kubernetes/azure/devops-pipelines/templates/install-thunder.yaml
@@ -38,13 +38,11 @@ parameters:
   - name: RUN_SETUP_SCRIPT
     type: boolean
     default: true
-  - name: CACHE_ENABLED
-    type: boolean
-    default: false
-  - name: CACHE_TYPE
+  - name: CACHE_MODE
     type: string
-    default: 'redis'
+    default: 'disabled'
     values:
+      - disabled
       - in-memory
       - redis
 
@@ -60,6 +58,19 @@ steps:
       inlineScript: |
         set -e
         echo "Installing Thunder Helm Chart"
+
+        CACHE_FLAGS=""
+        if [[ "$CACHE_MODE" == "redis" ]]; then
+          REDIS_CLUSTER_IP=$(kubectl get svc $(REDIS_RELEASE_NAME)-master -n $(REDIS_NAMESPACE) -o jsonpath='{.spec.clusterIP}')
+          echo "Resolved Redis ClusterIP: $REDIS_CLUSTER_IP"
+          CACHE_FLAGS="--set configuration.cache.type=redis \
+            --set configuration.cache.redis.address=${REDIS_CLUSTER_IP}:6379 \
+            --set configuration.cache.redis.password=$(REDIS-PASSWORD) \
+            --set configuration.cache.redis.db=0 \
+            --set configuration.cache.redis.key_prefix=thunderid:"
+        elif [[ "$CACHE_MODE" == "in-memory" ]]; then
+          CACHE_FLAGS="--set configuration.cache.type=in-memory"
+        fi
 
         RUNTIME_DB_FLAGS=""
         if [[ "$(RUNTIME_DB_TYPE)" == "redis" ]]; then
@@ -125,30 +136,9 @@ steps:
           --set deployment.livenessProbe.periodSeconds=1 \
           --set deployment.readinessProbe.initialDelaySeconds=0 \
           --set deployment.readinessProbe.periodSeconds=1 \
-          --set configuration.cache.disabled=false
-
-        if [[ "$CACHE_ENABLED" == "true" || "$CACHE_ENABLED" == "True" ]]; then
-          if [[ "$CACHE_TYPE" == "redis" ]]; then
-            REDIS_CLUSTER_IP=$(kubectl get svc $(REDIS_RELEASE_NAME)-master -n $(REDIS_NAMESPACE) -o jsonpath='{.spec.clusterIP}')
-            echo "Resolved Redis ClusterIP: $REDIS_CLUSTER_IP"
-            helm upgrade --install ${{ parameters.RELEASE_NAME }} . \
-              --namespace ${{ parameters.NAMESPACE }} \
-              --reuse-values \
-              --set configuration.cache.disabled=false \
-              --set configuration.cache.type=redis \
-              --set configuration.cache.redis.address="${REDIS_CLUSTER_IP}:6379" \
-              --set configuration.cache.redis.password=$(REDIS-PASSWORD) \
-              --set configuration.cache.redis.db=0 \
-              --set configuration.cache.redis.key_prefix="thunderid:"
-          elif [[ "$CACHE_TYPE" == "in-memory" ]]; then
-            helm upgrade --install ${{ parameters.RELEASE_NAME }} . \
-              --namespace ${{ parameters.NAMESPACE }} \
-              --reuse-values \
-              --set configuration.cache.disabled=false
-          fi
-        fi
+          --set configuration.cache.disabled=false \
+          $CACHE_FLAGS
 
         echo "Thunder Helm Chart installed successfully"
     env:
-      CACHE_ENABLED: ${{ parameters.CACHE_ENABLED }}
-      CACHE_TYPE: ${{ parameters.CACHE_TYPE }}
+      CACHE_MODE: ${{ parameters.CACHE_MODE }}

--- a/kubernetes/azure/devops-pipelines/templates/reinstall-thunder.yaml
+++ b/kubernetes/azure/devops-pipelines/templates/reinstall-thunder.yaml
@@ -38,13 +38,11 @@ parameters:
   - name: RUN_SETUP_SCRIPT
     type: boolean
     default: false
-  - name: CACHE_ENABLED
-    type: boolean
-    default: false
-  - name: CACHE_TYPE
+  - name: CACHE_MODE
     type: string
-    default: "redis"
+    default: "disabled"
     values:
+      - disabled
       - in-memory
       - redis
 
@@ -82,5 +80,4 @@ steps:
       THUNDER_IMAGE_TAG: ${{ parameters.THUNDER_IMAGE_TAG }}
       SKIP_SECURITY: ${{ parameters.SKIP_SECURITY }}
       RUN_SETUP_SCRIPT: ${{ parameters.RUN_SETUP_SCRIPT }}
-      CACHE_ENABLED: ${{ parameters.CACHE_ENABLED }}
-      CACHE_TYPE: ${{ parameters.CACHE_TYPE }}
+      CACHE_MODE: ${{ parameters.CACHE_MODE }}


### PR DESCRIPTION
## Purpose 

This pull request refactors and simplifies the configuration and logic for cache and database setup in the Thunder deployment and performance test pipelines. The main changes include consolidating cache-related parameters, improving Redis installation idempotency, and streamlining user seeding and database cleanup logic.

**Cache configuration simplification and improvement:**
- Replaced separate `CACHE_ENABLED` (boolean) and `CACHE_TYPE` (string) parameters with a single `CACHE_MODE` (string) parameter across all relevant pipeline YAML files. The new `CACHE_MODE` supports values: `disabled`, `in-memory`, and `redis`, with `disabled` as the default. This change simplifies cache configuration and usage throughout the pipelines. [[1]](diffhunk://#diff-2715d568be2e8f941503398285e8c41e1b1191249f0de021d059d04953bfb114L62-R74) [[2]](diffhunk://#diff-ae51a7e66c1c2a774330abf89748884bca67c3ed0992166ba6babea007a1029eL112-R117) [[3]](diffhunk://#diff-6b23283457c243536549d789732bba0f527048800689290a0eedd213cada2bb6L41-R45) [[4]](diffhunk://#diff-96a26f2ff8071e1aec146dace9a3b32e5e38d59ecba3ef09ff1ca5fb9e70a624L41-R45)
- Updated all jobs, variables, and templates to use `CACHE_MODE` instead of the old cache parameters, ensuring consistent cache logic and environment variable passing. [[1]](diffhunk://#diff-2715d568be2e8f941503398285e8c41e1b1191249f0de021d059d04953bfb114L208-R198) [[2]](diffhunk://#diff-ae51a7e66c1c2a774330abf89748884bca67c3ed0992166ba6babea007a1029eL259-R251) [[3]](diffhunk://#diff-6b23283457c243536549d789732bba0f527048800689290a0eedd213cada2bb6L128-R144) [[4]](diffhunk://#diff-96a26f2ff8071e1aec146dace9a3b32e5e38d59ecba3ef09ff1ca5fb9e70a624L85-R83)

**Redis installation and idempotency:**
- Enhanced the Redis installation template to check if the Redis Helm release already exists in the target namespace, skipping installation if present to avoid overwriting existing data. [[1]](diffhunk://#diff-390958d36fc8ef9778c9072a0c2c741bb779945df2d781ef4146f47f2ddd29f9R44-R46) [[2]](diffhunk://#diff-390958d36fc8ef9778c9072a0c2c741bb779945df2d781ef4146f47f2ddd29f9R75)
- Updated Redis installation job conditions to use the new `CACHE_MODE` parameter and also trigger installation if `RUNTIME_DB_TYPE` is set to `redis`. [[1]](diffhunk://#diff-2715d568be2e8f941503398285e8c41e1b1191249f0de021d059d04953bfb114L181-R172) [[2]](diffhunk://#diff-ae51a7e66c1c2a774330abf89748884bca67c3ed0992166ba6babea007a1029eL232-R226)

**Database and user seeding logic:**
- Replaced the boolean `CLEANUP_DB` parameter with a string `CLEANUP_TARGET` parameter, supporting values `none`, `all`, `runtime`, and `user` for more granular control. The default is now `none`. Adjusted related job conditions accordingly. [[1]](diffhunk://#diff-2715d568be2e8f941503398285e8c41e1b1191249f0de021d059d04953bfb114L30-R35) [[2]](diffhunk://#diff-2715d568be2e8f941503398285e8c41e1b1191249f0de021d059d04953bfb114L163-R153)
- Removed the boolean `SEED_USERS` parameter and replaced it with a numeric `SEED_USERS_COUNT` parameter (default `0`), clarifying that setting it to `0` skips user seeding. Updated job conditions to match. [[1]](diffhunk://#diff-2715d568be2e8f941503398285e8c41e1b1191249f0de021d059d04953bfb114L62-R74) [[2]](diffhunk://#diff-2715d568be2e8f941503398285e8c41e1b1191249f0de021d059d04953bfb114L239-R228)

**Other improvements:**
- Updated Thunder installation logic to use the new cache configuration flags and environment variables, ensuring proper cache backend setup in Helm deployments.
- Cleaned up obsolete variables and parameters related to the old cache and database logic for clarity and maintainability.

These changes collectively make the deployment pipelines easier to configure, safer to rerun, and more robust in handling cache and database setup scenarios.