### PR TITLE
Split the postgres server to three for each database

### DIFF
--- a/kubernetes/azure/devops-pipelines/execute-terraform.yaml
+++ b/kubernetes/azure/devops-pipelines/execute-terraform.yaml
@@ -37,9 +37,27 @@ parameters:
     type: string
     displayName: "Terraform Performance Repository Branch"
     default: "main"
-  - name: POSTGRES_SERVER_SKU
+  - name: POSTGRES_CONFIG_SERVER_SKU
     type: string
-    displayName: "PostgreSQL Server SKU"
+    displayName: "Config PostgreSQL Server SKU"
+    default: "GP_Standard_D2s_v3"
+    values:
+      - "GP_Standard_D2s_v3"
+      - "GP_Standard_D4s_v3"
+      - "GP_Standard_D8s_v3"
+      - "GP_Standard_D16s_v3"
+  - name: POSTGRES_RUNTIME_SERVER_SKU
+    type: string
+    displayName: "Runtime PostgreSQL Server SKU"
+    default: "GP_Standard_D2s_v3"
+    values:
+      - "GP_Standard_D2s_v3"
+      - "GP_Standard_D4s_v3"
+      - "GP_Standard_D8s_v3"
+      - "GP_Standard_D16s_v3"
+  - name: POSTGRES_USER_SERVER_SKU
+    type: string
+    displayName: "User PostgreSQL Server SKU"
     default: "GP_Standard_D2s_v3"
     values:
       - "GP_Standard_D2s_v3"
@@ -279,7 +297,9 @@ stages:
                 terraform apply \
                   -var-file="../conf/thunder.conf.secrets.tfvars" \
                   -var-file="../conf/thunder.conf.tfvars" \
-                  -var="postgres_server_sku_name=${{ parameters.POSTGRES_SERVER_SKU }}" \
+                  -var="postgres_config_server_sku_name=${{ parameters.POSTGRES_CONFIG_SERVER_SKU }}" \
+                  -var="postgres_runtime_server_sku_name=${{ parameters.POSTGRES_RUNTIME_SERVER_SKU }}" \
+                  -var="postgres_user_server_sku_name=${{ parameters.POSTGRES_USER_SERVER_SKU }}" \
                   -auto-approve
             env:
               ARM_CLIENT_ID: $(ARM_CLIENT_ID)
@@ -303,14 +323,18 @@ stages:
                 terraform destroy -target=module.aks-cluster \
                   -var-file="../conf/thunder.conf.secrets.tfvars" \
                   -var-file="../conf/thunder.conf.tfvars" \
-                  -var="postgres_server_sku_name=${{ parameters.POSTGRES_SERVER_SKU }}" \
+                  -var="postgres_config_server_sku_name=${{ parameters.POSTGRES_CONFIG_SERVER_SKU }}" \
+                  -var="postgres_runtime_server_sku_name=${{ parameters.POSTGRES_RUNTIME_SERVER_SKU }}" \
+                  -var="postgres_user_server_sku_name=${{ parameters.POSTGRES_USER_SERVER_SKU }}" \
                   -auto-approve
 
                 # Then destroy the rest of the resources
                 terraform destroy \
                   -var-file="../conf/thunder.conf.secrets.tfvars" \
                   -var-file="../conf/thunder.conf.tfvars" \
-                  -var="postgres_server_sku_name=${{ parameters.POSTGRES_SERVER_SKU }}" \
+                  -var="postgres_config_server_sku_name=${{ parameters.POSTGRES_CONFIG_SERVER_SKU }}" \
+                  -var="postgres_runtime_server_sku_name=${{ parameters.POSTGRES_RUNTIME_SERVER_SKU }}" \
+                  -var="postgres_user_server_sku_name=${{ parameters.POSTGRES_USER_SERVER_SKU }}" \
                   -auto-approve
             env:
               ARM_CLIENT_ID: $(ARM_CLIENT_ID)

--- a/kubernetes/azure/devops-pipelines/perf-test-execution.yaml
+++ b/kubernetes/azure/devops-pipelines/perf-test-execution.yaml
@@ -187,21 +187,25 @@ jobs:
             fi
             echo "AKS Cluster started successfully"
       - task: AzureCLI@2
-        displayName: 'Start Postgres Server'
+        displayName: 'Start Postgres Servers'
         condition: always()
         inputs:
           azureSubscription: $(AZURE_SERVICE_CONNECTION_NAME)
           scriptType: 'bash'
           scriptLocation: 'inlineScript'
           inlineScript: |
-            echo "Starting Postgres Server..."
-            if ! az postgres flexible-server start --name $(POSTGRES_SERVER_NAME) --resource-group $(RESOURCE_GROUP_NAME); then
-              echo "Error: Failed to start Postgres Server $(POSTGRES_SERVER_NAME)"
-              echo "##vso[task.logissue type=error]Failed to start Postgres Server $(POSTGRES_SERVER_NAME)"
-              echo "##vso[task.complete result=Failed;]"
-              exit 1
-            fi
-            echo "Postgres Server started successfully"
+            echo "Starting Postgres Servers..."
+            for SERVER_NAME in $(POSTGRES_CONFIG_SERVER_NAME) $(POSTGRES_RUNTIME_SERVER_NAME) $(POSTGRES_USER_SERVER_NAME); do
+              echo "Starting $SERVER_NAME..."
+              if ! az postgres flexible-server start --name $SERVER_NAME --resource-group $(RESOURCE_GROUP_NAME); then
+                echo "Error: Failed to start Postgres Server $SERVER_NAME"
+                echo "##vso[task.logissue type=error]Failed to start Postgres Server $SERVER_NAME"
+                echo "##vso[task.complete result=Failed;]"
+                exit 1
+              fi
+              echo "$SERVER_NAME started successfully"
+            done
+            echo "All Postgres Servers started successfully"
 
   - job: reinstall_thunder
     displayName: Reinstall Thunder
@@ -267,7 +271,7 @@ jobs:
           GITHUB_USERNAME: $(gitUsername)
           BUILD_TYPE: $(Build.Reason)
           BUILD_PATH: $(Build.ArtifactStagingDirectory)
-          DATABASE_HOST_NAME: $(DATABASE_HOSTNAME)
+          DATABASE_HOST_NAME: $(CONFIG_DB_HOSTNAME)
           THUNDER_HOST_NAME: $(THUNDER_HOSTNAME)
           POPULATE_TEST_DATA: "false"
           TEST_DURATION: ${{parameters.TEST_DURATION}}
@@ -330,18 +334,22 @@ jobs:
             fi
             echo "AKS Cluster stopped successfully"
       - task: AzureCLI@2
-        displayName: 'Stop Postgres Server'
+        displayName: 'Stop Postgres Servers'
         condition: always()
         inputs:
           azureSubscription: $(AZURE_SERVICE_CONNECTION_NAME)
           scriptType: 'bash'
           scriptLocation: 'inlineScript'
           inlineScript: |
-            echo "Stopping Postgres Server..."
-            if ! az postgres flexible-server stop --name $(POSTGRES_SERVER_NAME) --resource-group $(RESOURCE_GROUP_NAME); then
-              echo "Error: Failed to stop Postgres Server $(POSTGRES_SERVER_NAME)"
-              echo "##vso[task.logissue type=error]Failed to stop Postgres Server $(POSTGRES_SERVER_NAME)"
-              echo "##vso[task.complete result=Failed;]"
-              exit 1
-            fi
-            echo "Postgres Server stopped successfully"
+            echo "Stopping Postgres Servers..."
+            for SERVER_NAME in $(POSTGRES_CONFIG_SERVER_NAME) $(POSTGRES_RUNTIME_SERVER_NAME) $(POSTGRES_USER_SERVER_NAME); do
+              echo "Stopping $SERVER_NAME..."
+              if ! az postgres flexible-server stop --name $SERVER_NAME --resource-group $(RESOURCE_GROUP_NAME); then
+                echo "Error: Failed to stop Postgres Server $SERVER_NAME"
+                echo "##vso[task.logissue type=error]Failed to stop Postgres Server $SERVER_NAME"
+                echo "##vso[task.complete result=Failed;]"
+                exit 1
+              fi
+              echo "$SERVER_NAME stopped successfully"
+            done
+            echo "All Postgres Servers stopped successfully"

--- a/kubernetes/azure/devops-pipelines/variables.yaml
+++ b/kubernetes/azure/devops-pipelines/variables.yaml
@@ -22,13 +22,17 @@ variables:
   RESOURCE_GROUP_NAME: 'rg-$(PROJECT)-$(ENVIRONMENT)-$(LOCATION)-$(PADDING)'
   AKS_CLUSTER_NAME: 'aks-$(PROJECT)-$(ENVIRONMENT)-$(LOCATION)-$(PADDING)'
   VM_NAME: 'vm$(PROJECT)-$(ENVIRONMENT)-runner-$(LOCATION)-$(PADDING)'
-  POSTGRES_SERVER_NAME: 'postgresql-$(PROJECT)-$(ENVIRONMENT)-$(LOCATION)-$(PADDING)'
+  POSTGRES_CONFIG_SERVER_NAME: 'postgresql-$(PROJECT)-config-$(ENVIRONMENT)-$(LOCATION)-$(PADDING)'
+  POSTGRES_RUNTIME_SERVER_NAME: 'postgresql-$(PROJECT)-runtime-$(ENVIRONMENT)-$(LOCATION)-$(PADDING)'
+  POSTGRES_USER_SERVER_NAME: 'postgresql-$(PROJECT)-user-$(ENVIRONMENT)-$(LOCATION)-$(PADDING)'
+  CONFIG_DB_HOSTNAME: '$(POSTGRES_CONFIG_SERVER_NAME).postgres.database.azure.com'
+  RUNTIME_DB_HOSTNAME: '$(POSTGRES_RUNTIME_SERVER_NAME).postgres.database.azure.com'
+  USER_DB_HOSTNAME: '$(POSTGRES_USER_SERVER_NAME).postgres.database.azure.com'
   INTERNAL_NGINX_CONTROLLER_LB_INTERNAL_IP: "10.0.2.5"
   INTERNAL_NGINX_CONTROLLER_LB_INTERNAL_SUBNET: "snet-aksinternallbthunder-$(PADDING)"
   TLS_SECRET_NAME: "thunder-tls"
   THUNDER_KUBERNETES_INGRESS: "thunder-perf-thunderid-ingress"
   THUNDER_HOSTNAME: "thunderid.local"
-  DATABASE_HOSTNAME: 'postgresql-thunder-perf-eastus2-001.postgres.database.azure.com'
   SKIP_SECURITY: 'true'
 
   # Thunder Deployment Configuration
@@ -50,15 +54,15 @@ variables:
   # Database Configuration
   CONFIG_DB_TYPE: 'postgres'
   CONFIG_DB_NAME: 'configdb'
-  CONFIG_DB_HOST: $(DATABASE_HOSTNAME)
+  CONFIG_DB_HOST: $(CONFIG_DB_HOSTNAME)
   CONFIG_DB_PORT: '5432'
   RUNTIME_DB_TYPE: 'postgres'
   RUNTIME_DB_NAME: 'runtimedb'
-  RUNTIME_DB_HOST: $(DATABASE_HOSTNAME)
+  RUNTIME_DB_HOST: $(RUNTIME_DB_HOSTNAME)
   RUNTIME_DB_PORT: '5432'
   USER_DB_TYPE: 'postgres'
   USER_DB_NAME: 'userdb'
-  USER_DB_HOST: $(DATABASE_HOSTNAME)
+  USER_DB_HOST: $(USER_DB_HOSTNAME)
   USER_DB_PORT: '5432'
 
   # Database Connection Pool Configuration

--- a/kubernetes/azure/terraform/conf/thunder.conf.tfvars
+++ b/kubernetes/azure/terraform/conf/thunder.conf.tfvars
@@ -31,9 +31,12 @@ default_node_pool_min_count    = 2
 default_node_pool_max_count    = 5
 
 # Postgres configuration
-postgres_server_version        = "17"
-postgres_server_storage_size   = 32768
-postgres_server_sku_name       = "GP_Standard_D2s_v3"
+postgres_server_version              = "17"
+postgres_server_storage_size         = 32768
+postgres_config_server_sku_name      = "GP_Standard_D2s_v3"
+postgres_runtime_server_sku_name     = "GP_Standard_D2s_v3"
+postgres_user_server_sku_name        = "GP_Standard_D2s_v3"
+postgres_userdb_server_storage_size  = 131072
 
 # VM configuration
 vm_size             = "Standard_F8s_v2"

--- a/kubernetes/azure/terraform/deployment/main.tf
+++ b/kubernetes/azure/terraform/deployment/main.tf
@@ -139,9 +139,9 @@ module "private-dns-postgres" {
   tags                  = local.default_tags
 }
 
-module "postgres-server" {
+module "postgres-config-server" {
   source                           = "git::https://github.com/wso2/azure-terraform-modules.git//modules/azurerm/PostgreSQL-Flexible-Server?ref=v2.18.10"
-  server_name                      = join("-", [var.project, var.environment, var.location, var.padding])
+  server_name                      = join("-", [var.project, "config", var.environment, var.location, var.padding])
   resource_group_name              = module.resource-group.resource_group_name
   subnet_id                        = module.postgres-vm-subnet.subnet_id
   private_dns_zone_id              = module.private-dns-postgres.private_dns_zone_id
@@ -150,26 +150,56 @@ module "postgres-server" {
   postgresql_server_admin_username = var.postgres_server_admin_username
   postgresql_server_admin_password = var.postgres_server_admin_password
   storage_size                     = var.postgres_server_storage_size
-  sku_name                         = var.postgres_server_sku_name
+  sku_name                         = var.postgres_config_server_sku_name
   tags                             = local.default_tags
 }
 
 module "postgres-config-db" {
   source             = "git::https://github.com/wso2/azure-terraform-modules.git//modules/azurerm/PostgreSQL-Flexible-Server-Database?ref=v2.18.10"
   database_full_name = var.config_db_name
-  server_id          = module.postgres-server.postgresql_server_id
+  server_id          = module.postgres-config-server.postgresql_server_id
+}
+
+module "postgres-runtime-server" {
+  source                           = "git::https://github.com/wso2/azure-terraform-modules.git//modules/azurerm/PostgreSQL-Flexible-Server?ref=v2.18.10"
+  server_name                      = join("-", [var.project, "runtime", var.environment, var.location, var.padding])
+  resource_group_name              = module.resource-group.resource_group_name
+  subnet_id                        = module.postgres-vm-subnet.subnet_id
+  private_dns_zone_id              = module.private-dns-postgres.private_dns_zone_id
+  location                         = var.location
+  postgresql_server_version        = var.postgres_server_version
+  postgresql_server_admin_username = var.postgres_server_admin_username
+  postgresql_server_admin_password = var.postgres_server_admin_password
+  storage_size                     = var.postgres_server_storage_size
+  sku_name                         = var.postgres_runtime_server_sku_name
+  tags                             = local.default_tags
 }
 
 module "postgres-runtime-db" {
   source             = "git::https://github.com/wso2/azure-terraform-modules.git//modules/azurerm/PostgreSQL-Flexible-Server-Database?ref=v2.18.10"
   database_full_name = var.runtime_db_name
-  server_id          = module.postgres-server.postgresql_server_id
+  server_id          = module.postgres-runtime-server.postgresql_server_id
+}
+
+module "postgres-user-server" {
+  source                           = "git::https://github.com/wso2/azure-terraform-modules.git//modules/azurerm/PostgreSQL-Flexible-Server?ref=v2.18.10"
+  server_name                      = join("-", [var.project, "user", var.environment, var.location, var.padding])
+  resource_group_name              = module.resource-group.resource_group_name
+  subnet_id                        = module.postgres-vm-subnet.subnet_id
+  private_dns_zone_id              = module.private-dns-postgres.private_dns_zone_id
+  location                         = var.location
+  postgresql_server_version        = var.postgres_server_version
+  postgresql_server_admin_username = var.postgres_server_admin_username
+  postgresql_server_admin_password = var.postgres_server_admin_password
+  storage_size                     = var.postgres_userdb_server_storage_size
+  sku_name                         = var.postgres_user_server_sku_name
+  tags                             = local.default_tags
 }
 
 module "postgres-user-db" {
   source             = "git::https://github.com/wso2/azure-terraform-modules.git//modules/azurerm/PostgreSQL-Flexible-Server-Database?ref=v2.18.10"
   database_full_name = var.user_db_name
-  server_id          = module.postgres-server.postgresql_server_id
+  server_id          = module.postgres-user-server.postgresql_server_id
 }
 
 # VM

--- a/kubernetes/azure/terraform/deployment/variables.tf
+++ b/kubernetes/azure/terraform/deployment/variables.tf
@@ -183,10 +183,28 @@ variable "postgres_server_storage_size" {
   default     = 32768
 }
 
-variable "postgres_server_sku_name" {
-  description = "The SKU name for the Postgres server"
+variable "postgres_config_server_sku_name" {
+  description = "The SKU name for the config Postgres server"
   type        = string
   default     = "GP_Standard_D2s_v3"
+}
+
+variable "postgres_runtime_server_sku_name" {
+  description = "The SKU name for the runtime Postgres server"
+  type        = string
+  default     = "GP_Standard_D2s_v3"
+}
+
+variable "postgres_user_server_sku_name" {
+  description = "The SKU name for the user Postgres server"
+  type        = string
+  default     = "GP_Standard_D2s_v3"
+}
+
+variable "postgres_userdb_server_storage_size" {
+  description = "The storage size in GB for the user Postgres server"
+  type        = number
+  default     = 131072
 }
 
 # Database name variables


### PR DESCRIPTION
## Purpose

This pull request introduces significant changes to support the use of three separate PostgreSQL servers (config, runtime, and user) instead of a single server, across the Azure Kubernetes deployment, Terraform infrastructure, and DevOps pipelines. It updates variable names, resource definitions, and pipeline scripts to handle the new multi-server architecture, ensuring each database type has its own server with customizable SKU and storage settings.

**Infrastructure and Terraform changes:**

* Refactored Terraform to provision three distinct PostgreSQL Flexible Servers (`config`, `runtime`, and `user`), each with its own module, SKU, and storage configuration. The corresponding database modules now reference the appropriate server modules. (`kubernetes/azure/terraform/deployment/main.tf`, `kubernetes/azure/terraform/conf/thunder.conf.tfvars`, `kubernetes/azure/terraform/deployment/variables.tf`) [[1]](diffhunk://#diff-c0970b31341ced79ad8efed386d36e50daef400043d42d6d8092d87cbc33df83L142-R144) [[2]](diffhunk://#diff-c0970b31341ced79ad8efed386d36e50daef400043d42d6d8092d87cbc33df83L153-R202) [[3]](diffhunk://#diff-c4179c16d2124d6720983636d9b8f115622a93ea2e561e3c4a2eee726b4a2870L186-R209) [[4]](diffhunk://#diff-cc8223c1d796bd7bbbe5ae3accf8e1f2751d17068ab087473acc885c2a797c55L36-R39)

* Updated all related variable definitions and defaults to support the new server names and hostnames, including new variables for each server's SKU and storage size. (`kubernetes/azure/terraform/deployment/variables.tf`, `kubernetes/azure/devops-pipelines/variables.yaml`) [[1]](diffhunk://#diff-c4179c16d2124d6720983636d9b8f115622a93ea2e561e3c4a2eee726b4a2870L186-R209) [[2]](diffhunk://#diff-a8fbba1caf1074387c84d03072a4494f7afa45f0f959895825f1242a78c1bea7L25-L31) [[3]](diffhunk://#diff-a8fbba1caf1074387c84d03072a4494f7afa45f0f959895825f1242a78c1bea7L53-R65)

**DevOps pipeline changes:**

* Modified pipeline parameters and stages to accept and pass separate SKUs for each PostgreSQL server, and updated Terraform commands to use the new variables. (`kubernetes/azure/devops-pipelines/execute-terraform.yaml`) [[1]](diffhunk://#diff-e3d8b36c12d5351bf4002956290bf1709d4a0a870f593a4139dc23c03fc483b2L40-R60) [[2]](diffhunk://#diff-e3d8b36c12d5351bf4002956290bf1709d4a0a870f593a4139dc23c03fc483b2L282-R302) [[3]](diffhunk://#diff-e3d8b36c12d5351bf4002956290bf1709d4a0a870f593a4139dc23c03fc483b2L306-R337)

* Updated performance test execution pipeline to start and stop all three PostgreSQL servers using loops, and adjusted display names and error handling accordingly. (`kubernetes/azure/devops-pipelines/perf-test-execution.yaml`) [[1]](diffhunk://#diff-ae51a7e66c1c2a774330abf89748884bca67c3ed0992166ba6babea007a1029eL190-R208) [[2]](diffhunk://#diff-ae51a7e66c1c2a774330abf89748884bca67c3ed0992166ba6babea007a1029eL333-R355)

* Replaced the generic database hostname with the appropriate config, runtime, and user hostnames throughout the variable and environment definitions. (`kubernetes/azure/devops-pipelines/variables.yaml`, `kubernetes/azure/devops-pipelines/perf-test-execution.yaml`) [[1]](diffhunk://#diff-a8fbba1caf1074387c84d03072a4494f7afa45f0f959895825f1242a78c1bea7L25-L31) [[2]](diffhunk://#diff-a8fbba1caf1074387c84d03072a4494f7afa45f0f959895825f1242a78c1bea7L53-R65) [[3]](diffhunk://#diff-ae51a7e66c1c2a774330abf89748884bca67c3ed0992166ba6babea007a1029eL270-R274)

These changes collectively enable isolated management, scaling, and configuration for each database workload, improving flexibility and maintainability of the deployment.