### PR TITLE
Update thuderid repo URL

### DIFF
--- a/.github/workflows/vm-perf-workflow.yml
+++ b/.github/workflows/vm-perf-workflow.yml
@@ -378,7 +378,7 @@ jobs:
           retention-days: 30
 
       - name: Publish test results to GitHub
-        if: inputs.PUSH_BENCHMARKS_TO_GITHUB == true && startsWith(inputs.THUNDER_PACK_URL, 'https://github.com/asgardeo/thunder/releases/download/')
+        if: inputs.PUSH_BENCHMARKS_TO_GITHUB == true && startsWith(inputs.THUNDER_PACK_URL, 'https://github.com/thunder-id/thunderid/releases/download/')
         env:
           DEPLOYMENT: ${{ inputs.DEPLOYMENT }}
           THUNDER_PACK_URL: ${{ inputs.THUNDER_PACK_URL }}


### PR DESCRIPTION
## Purpose

This pull request updates the GitHub Actions workflow to use the correct Thunder pack URL when publishing test results. The change ensures that benchmarks are only pushed if the `THUNDER_PACK_URL` uses the new repository path.

Workflow update:

* Updated the conditional in `.github/workflows/vm-perf-workflow.yml` to check for the new Thunder pack URL (`https://github.com/thunder-id/thunderid/releases/download/`) instead of the old one.