### PR TITLE
Clarify database information in readme

### DIFF
--- a/benchmarks/v0.40.0/kubernetes/readme.md
+++ b/benchmarks/v0.40.0/kubernetes/readme.md
@@ -49,7 +49,7 @@ Run: https://dev.azure.com/WSO2-Thunder/thunder-performance/_build/results?build
 - Nodes: 5 nodes (F32s_v2)
 - Thunder Pods: 4 vCore + 2Gi, min-pods: 15, max-pods: 32, running: 32
 - Heap Size: 4g
-- Database: Postgres (legacy DB)
+- Database: Postgres
 - Caching: In-Memory
 
 | Scenario Name | Concurrent Users | Label | # Samples | Error Count | Error % | Throughput (Requests/sec) | Average Response Time (ms) | 95th Percentile of Response Time (ms) |


### PR DESCRIPTION

## Purpose
This pull request makes a minor update to the benchmark documentation for version 0.40.0. The change clarifies the database used in the Kubernetes benchmark setup.

- Documentation update:
  * Updated the description of the database from "Postgres (legacy DB)" to simply "Postgres" in `benchmarks/v0.40.0/kubernetes/readme.md` to reflect the current database configuration.