### PR TITLE
Update perf tests for v0.0.45

### DIFF
--- a/perf-scripts/common/deployment/setup/update-thunder-conf.sh
+++ b/perf-scripts/common/deployment/setup/update-thunder-conf.sh
@@ -21,7 +21,7 @@
 
 function update_postgres_config() {
 
-    sed -i "s|{db_hostname}|$db_instance_ip|g" "$carbon_home/repository/conf/deployment.yaml" || echo "Editing deployment.yaml file failed!"
+    sed -i "s|{db_hostname}|$db_instance_ip|g" "$carbon_home/deployment.yaml" || echo "Editing deployment.yaml file failed!"
 }
 
 function usage() {
@@ -80,7 +80,7 @@ carbon_home=$(realpath ~/thunder)
 echo ""
 echo "Adding deployment yaml file to the pack..."
 echo "-------------------------------------------"
-cp resources/deployment.yaml "$carbon_home"/repository/conf/deployment.yaml
+cp resources/deployment.yaml "$carbon_home"/deployment.yaml
 
 echo ""
 echo "Applying basic parameter changes..."

--- a/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
+++ b/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
@@ -211,7 +211,7 @@
             &quot;id&quot;: &quot;basic_auth&quot;,&#xd;
             &quot;type&quot;: &quot;TASK_EXECUTION&quot;,&#xd;
             &quot;executor&quot;: {&#xd;
-                &quot;name&quot;: &quot;BasicAuthExecutor&quot;&#xd;
+                &quot;name&quot;: &quot;CredentialsAuthExecutor&quot;&#xd;
             },&#xd;
             &quot;onSuccess&quot;: &quot;auth_assert&quot;,&#xd;
             &quot;onIncomplete&quot;: &quot;prompt_credentials&quot;&#xd;

--- a/perf-scripts/single-node/setup/resources/deployment.yaml
+++ b/perf-scripts/single-node/setup/resources/deployment.yaml
@@ -26,8 +26,8 @@ gate_client:
   error_path: "/error"
 
 tls:
-  cert_file: "repository/resources/security/server.cert"
-  key_file: "repository/resources/security/server.key"
+  cert_file: "config/certs/server.cert"
+  key_file: "config/certs/server.key"
   min_version: "1.2"
 
 database:


### PR DESCRIPTION
## Purpose

This PR updates the performance tests to be compatible with ThunderID v0.0.45.

Contains 2 main fixes
1. Update directory paths to fix breaking changes due to https://github.com/thunder-id/thunderid/pull/3300
2. Update references to BasicAuthExecutor to fix breaking changes due to https://github.com/thunder-id/thunderid/pull/2777
