### PR TITLE
Add running perf tests in detached mode

### DIFF
--- a/.github/scripts/vm-perf-trigger-script.sh
+++ b/.github/scripts/vm-perf-trigger-script.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# ----------------------------------------------------------------------------
+# Kick off VM Performance tests on AWS in detached mode.
+# Runs setup on the runner then launches JMeter on the bastion via nohup.
+# Exits after kickoff; does not wait for the test to complete.
+# ----------------------------------------------------------------------------
+
+echo "WORKSPACE Directory: $WORKSPACE"
+echo "RESOURCES Directory: $RESOURCES_DIR"
+
+echo ""
+echo "Starting detached performance test with params:"
+echo "    DEPLOYMENT: $DEPLOYMENT"
+echo "    CONCURRENCY: $CONCURRENCY"
+echo "    DB_TYPE: $DB_TYPE"
+echo "    BUILD_CAUSE: $BUILD_CAUSE"
+echo "    Build Triggered By $BUILD_USER_EMAIL"
+echo "=========================================================="
+
+cd $WORKSPACE/perf-scripts/$DEPLOYMENT
+
+echo ""
+echo "Kicking off performance test in detached mode..."
+
+cmd="./start-performance.sh -k $RESOURCES_DIR/thunder-perf-test.pem \
+-c is-perf-cert -j $RESOURCES_DIR/apache-jmeter-5.6.3.tgz -n $WORKSPACE/thunder.zip -q $BUILD_USER_EMAIL -m $DB_TYPE -r $CONCURRENCY -f $DEPLOYMENT -z $USE_DELAYS "
+
+if [[ ! -z $ADDITIONAL_PARAMS_TO_RUN_PERFORMANCE_SCRIPT ]]; then
+	cmd+=" -- $ADDITIONAL_PARAMS_TO_RUN_PERFORMANCE_SCRIPT"
+fi
+
+echo "$cmd"
+
+echo "perf_test_start_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+# Detached mode: start-performance.sh will nohup-launch JMeter on the bastion and exit early.
+export DETACHED_RUN=1
+eval $cmd
+kickoff_rc=$?
+unset DETACHED_RUN
+
+echo "perf_test_kickoff_end_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+echo "=========================================================="
+
+exit $kickoff_rc

--- a/.github/workflows/vm-perf-trigger.yml
+++ b/.github/workflows/vm-perf-trigger.yml
@@ -1,0 +1,437 @@
+name: VM Performance Test on AWS (Detached, for >6h runs)
+
+# Kicks off a long-running JMeter test on the bastion and exits.
+# The JMeter run continues on the bastion after this workflow completes.
+# Retrieving results, viewing logs mid-run, and tearing down the CloudFormation
+# stack are all manual in this phase — see the trigger run's job summary for
+# copy-paste commands and AWS Console links.
+
+on:
+  workflow_dispatch:
+    inputs:
+      REPO_REF:
+        description: 'Git ref (branch, tag, or commit SHA) to checkout'
+        required: false
+        default: ''
+        type: string
+      THUNDER_PACK_URL:
+        description: 'URL to download Thunder pack'
+        required: true
+        default: 'https://github.com/asgardeo/thunder/releases/download/v0.7.0/thunder-v0.7.0-linux-x64.zip'
+        type: string
+      DEPLOYMENT:
+        description: 'Deployment type'
+        required: true
+        default: 'single-node'
+        type: choice
+        options:
+          - single-node
+      THUNDER_INSTANCE_TYPE:
+        description: 'Thunder VM instance type'
+        required: true
+        default: 't2.nano'
+        type: choice
+        options:
+          - t2.nano
+          - t2.micro
+          - t2.small
+          - t3a.nano
+          - t3a.micro
+          - t3a.small
+          - t3a.medium
+          - t3a.large
+          - t3a.xlarge
+          - t3a.2xlarge
+          - m8i.large
+          - m8i.xlarge
+          - m8i.2xlarge
+      NGINX_INSTANCE_TYPE:
+        description: 'Nginx VM instance type'
+        required: true
+        default: 't2.nano'
+        type: choice
+        options:
+          - t2.nano
+          - t2.micro
+          - t2.small
+          - t3a.nano
+          - t3a.micro
+          - t3a.small
+          - t3a.medium
+          - t3a.large
+          - t3a.xlarge
+          - t3a.2xlarge
+          - m8i.large
+          - m8i.xlarge
+          - m8i.2xlarge
+      BASTION_INSTANCE_TYPE:
+        description: 'Bastion VM instance type'
+        required: true
+        default: 't3a.large'
+        type: choice
+        options:
+          - t2.nano
+          - t2.micro
+          - t2.small
+          - t3a.nano
+          - t3a.micro
+          - t3a.small
+          - t3a.medium
+          - t3a.large
+          - t3a.xlarge
+          - t3a.2xlarge
+          - m8i.large
+          - m8i.xlarge
+          - m8i.2xlarge
+      ADDITIONAL_PARAMS_TO_RUN_PERFORMANCE_SCRIPT:
+        description: 'Additional parameters for performance script'
+        required: true
+        default: '-d 15 -w 5 -x false -y JWT'
+        type: string
+      USE_DELAYS:
+        description: 'Enable delays in testing'
+        required: true
+        default: true
+        type: boolean
+      CONCURRENCY:
+        description: 'Concurrency (Comma-separated list)'
+        required: true
+        default: '50'
+        type: string
+      DB_INSTANCE_TYPE:
+        description: 'RDS DB instance type'
+        required: true
+        default: 'db.t3.medium'
+        type: choice
+        options:
+          - db.t3.medium
+          - db.t3.large
+          - db.t3.xlarge
+          - db.m6i.large
+          - db.m6i.xlarge
+          - db.m6i.2xlarge
+
+permissions:
+  contents: read
+
+jobs:
+  vm-perf-trigger:
+    runs-on: ubuntu-latest
+    env:
+      RESOURCES_DIR: ${{ github.workspace }}/resources
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ inputs.REPO_REF }}
+          persist-credentials: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-1
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Validate Concurrency input
+        run: |
+          concurrency="${{ inputs.CONCURRENCY }}"
+          if [[ -z "$concurrency" ]]; then
+            echo "Error: CONCURRENCY must not be empty."
+            exit 1
+          fi
+          IFS=',' read -ra levels <<< "$concurrency"
+          for level in "${levels[@]}"; do
+            level="${level// /}"
+            if ! [[ "$level" =~ ^[1-9][0-9]*$ ]]; then
+              echo "Error: '$level' is not a valid positive integer. CONCURRENCY must be a comma-separated list of positive integers (e.g. 50,100,150,300,500)."
+              exit 1
+            fi
+          done
+          echo "CONCURRENCY input is valid: $concurrency"
+
+      - name: Download Thunder Pack from URL
+        run: |
+          echo "Downloading Thunder Pack from URL..."
+          wget -q -O "${{ github.workspace }}/thunder.zip" "${{ inputs.THUNDER_PACK_URL }}"
+          echo "Thunder pack downloaded successfully."
+
+      - name: Download Infrastructure Resources
+        run: |
+          mkdir -p $RESOURCES_DIR
+          echo "Downloading thunder-perf-test.pem..."
+          aws s3 cp s3://performance-thunder/keys/thunder-perf-test.pem $RESOURCES_DIR/thunder-perf-test.pem --only-show-errors --no-progress
+          chmod 400 $RESOURCES_DIR/thunder-perf-test.pem
+          echo "Downloading apache-jmeter-5.6.3.tgz..."
+          aws s3 cp s3://performance-thunder-resources/apache-jmeter-5.6.3.tgz $RESOURCES_DIR/apache-jmeter-5.6.3.tgz --only-show-errors --no-progress
+
+      - name: Build Performance Tests
+        env:
+          DEPLOYMENT: ${{ inputs.DEPLOYMENT }}
+        run: |
+          cd $GITHUB_WORKSPACE/perf-scripts/$DEPLOYMENT
+          echo "Building performance test project: $DEPLOYMENT..."
+          mvn -q clean install
+
+      - name: Create CloudFormation Stack
+        id: create-cf-stack
+        env:
+          WORKSPACE: ${{ github.workspace }}
+          DEPLOYMENT: ${{ inputs.DEPLOYMENT }}
+          THUNDER_INSTANCE_TYPE: ${{ inputs.THUNDER_INSTANCE_TYPE }}
+          NGINX_INSTANCE_TYPE: ${{ inputs.NGINX_INSTANCE_TYPE }}
+          BASTION_INSTANCE_TYPE: ${{ inputs.BASTION_INSTANCE_TYPE }}
+          DB_INSTANCE_TYPE: ${{ inputs.DB_INSTANCE_TYPE }}
+          CONCURRENCY: ${{ inputs.CONCURRENCY }}
+          DB_TYPE: 'postgres'
+          BUILD_USER_EMAIL: ${{ github.actor }}@github.com
+        run: |
+          chmod +x .github/scripts/create-cf-stack.sh
+          bash .github/scripts/create-cf-stack.sh
+
+      - name: Execute VM Performance Test (Detached)
+        id: execute-perf-test
+        timeout-minutes: 15
+        env:
+          WORKSPACE: ${{ github.workspace }}
+          DEPLOYMENT: ${{ inputs.DEPLOYMENT }}
+          ADDITIONAL_PARAMS_TO_RUN_PERFORMANCE_SCRIPT: ${{ inputs.ADDITIONAL_PARAMS_TO_RUN_PERFORMANCE_SCRIPT }}
+          USE_DELAYS: ${{ inputs.USE_DELAYS }}
+          CONCURRENCY: ${{ inputs.CONCURRENCY }}
+          DB_TYPE: 'postgres'
+          BUILD_USER_EMAIL: ${{ github.actor }}@github.com
+          BUILD_CAUSE: ${{ github.event_name }}
+          BUILD_NUMBER: ${{ github.run_number }}
+          BASTION_NODE_IP: ${{ steps.create-cf-stack.outputs.bastion_node_ip }}
+          NGINX_INSTANCE_IP: ${{ steps.create-cf-stack.outputs.nginx_instance_ip }}
+          WSO2_THUNDER_1_IP: ${{ steps.create-cf-stack.outputs.wso2_thunder_1_ip }}
+          RDS_HOST: ${{ steps.create-cf-stack.outputs.rds_host }}
+        run: |
+          chmod +x .github/scripts/vm-perf-trigger-script.sh
+          bash .github/scripts/vm-perf-trigger-script.sh
+
+      - name: Verify JMeter is running on the bastion
+        id: verify-jmeter
+        timeout-minutes: 3
+        env:
+          BASTION_NODE_IP: ${{ steps.create-cf-stack.outputs.bastion_node_ip }}
+        run: |
+          # Give nohup a moment to actually invoke the script and start the process.
+          sleep 20
+          set +x
+          verify_output=$(ssh -i "${RESOURCES_DIR}/thunder-perf-test.pem" \
+            -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
+            -o ServerAliveInterval=10 -o ServerAliveCountMax=3 \
+            ubuntu@"${BASTION_NODE_IP}" \
+            'if pgrep -f run-performance-tests.sh >/dev/null; then
+               echo RUNNING
+             else
+               echo DEAD
+               echo "--- run.log tail ---"
+               tail -n 50 /home/ubuntu/run.log 2>/dev/null || echo "(no run.log yet)"
+             fi')
+          # Filter any accidental AWS access-key pattern before printing (belt-and-suspenders).
+          echo "$verify_output" | sed -E 's/AKIA[0-9A-Z]{16}/AKIA****REDACTED****/g'
+          echo "$verify_output" | head -1 | grep -q RUNNING || {
+            echo "::error::JMeter is NOT running on the bastion. See the log tail above for the crash reason."
+            exit 1
+          }
+          echo "verify_status=RUNNING" >> "$GITHUB_OUTPUT"
+
+      - name: Emit manifest artifact
+        env:
+          WORKSPACE: ${{ github.workspace }}
+          RUN_NUMBER: ${{ github.run_number }}
+          STACK_ID: ${{ steps.create-cf-stack.outputs.stack_id }}
+          BASTION_IP: ${{ steps.create-cf-stack.outputs.bastion_node_ip }}
+          BASTION_INSTANCE_ID: ${{ steps.create-cf-stack.outputs.bastion_instance_id }}
+          NGINX_INSTANCE_ID: ${{ steps.create-cf-stack.outputs.nginx_instance_id }}
+          THUNDER_INSTANCE_ID: ${{ steps.create-cf-stack.outputs.thunder_instance_id }}
+          RDS_INSTANCE_ID: ${{ steps.create-cf-stack.outputs.rds_instance_id }}
+          BASTION_INSTANCE_TYPE: ${{ steps.create-cf-stack.outputs.bastion_instance_type }}
+          NGINX_INSTANCE_TYPE: ${{ steps.create-cf-stack.outputs.nginx_instance_type }}
+          THUNDER_INSTANCE_TYPE: ${{ inputs.THUNDER_INSTANCE_TYPE }}
+          DB_INSTANCE_TYPE: ${{ inputs.DB_INSTANCE_TYPE }}
+          PERF_TEST_START_TIME: ${{ steps.execute-perf-test.outputs.perf_test_start_time }}
+          DEPLOYMENT: ${{ inputs.DEPLOYMENT }}
+          CONCURRENCY: ${{ inputs.CONCURRENCY }}
+          ADDITIONAL_PARAMS: ${{ inputs.ADDITIONAL_PARAMS_TO_RUN_PERFORMANCE_SCRIPT }}
+          USE_DELAYS: ${{ inputs.USE_DELAYS }}
+          REPO_REF: ${{ inputs.REPO_REF }}
+          THUNDER_PACK_URL: ${{ inputs.THUNDER_PACK_URL }}
+        run: |
+          # stack_id is a full ARN; extract the stack name (2nd-to-last path component).
+          stack_name=$(echo "$STACK_ID" | awk -F/ '{print $(NF-1)}')
+
+          jq -n \
+            --arg run_number "$RUN_NUMBER" \
+            --arg stack_name "$stack_name" \
+            --arg stack_id "$STACK_ID" \
+            --arg region "us-west-1" \
+            --arg bastion_ip "$BASTION_IP" \
+            --arg bastion_id "$BASTION_INSTANCE_ID" \
+            --arg nginx_id "$NGINX_INSTANCE_ID" \
+            --arg thunder_id "$THUNDER_INSTANCE_ID" \
+            --arg rds_id "$RDS_INSTANCE_ID" \
+            --arg bastion_type "$BASTION_INSTANCE_TYPE" \
+            --arg nginx_type "$NGINX_INSTANCE_TYPE" \
+            --arg thunder_type "$THUNDER_INSTANCE_TYPE" \
+            --arg db_type "$DB_INSTANCE_TYPE" \
+            --arg perf_test_start_time "$PERF_TEST_START_TIME" \
+            --arg deployment "$DEPLOYMENT" \
+            --arg concurrency "$CONCURRENCY" \
+            --arg additional_params "$ADDITIONAL_PARAMS" \
+            --arg use_delays "$USE_DELAYS" \
+            --arg repo_ref "$REPO_REF" \
+            --arg thunder_pack_url "$THUNDER_PACK_URL" \
+            '{
+              run_number: $run_number,
+              stack_name: $stack_name,
+              stack_id: $stack_id,
+              region: $region,
+              bastion_ip: $bastion_ip,
+              instance_ids: {
+                bastion: $bastion_id,
+                nginx:   $nginx_id,
+                thunder: $thunder_id,
+                rds:     $rds_id
+              },
+              instance_types: {
+                bastion: $bastion_type,
+                nginx:   $nginx_type,
+                thunder: $thunder_type,
+                rds:     $db_type
+              },
+              perf_test_start_time: $perf_test_start_time,
+              inputs: {
+                DEPLOYMENT: $deployment,
+                CONCURRENCY: $concurrency,
+                ADDITIONAL_PARAMS_TO_RUN_PERFORMANCE_SCRIPT: $additional_params,
+                USE_DELAYS: $use_delays,
+                REPO_REF: $repo_ref,
+                THUNDER_PACK_URL: $thunder_pack_url
+              }
+            }' > "$WORKSPACE/manifest.json"
+
+          echo "Manifest:"
+          cat "$WORKSPACE/manifest.json"
+
+      - name: Upload manifest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: manifest-${{ github.run_number }}
+          path: ${{ github.workspace }}/manifest.json
+          retention-days: 90
+
+      - name: Publish trigger summary
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
+          STACK_ID: ${{ steps.create-cf-stack.outputs.stack_id }}
+          BASTION_IP: ${{ steps.create-cf-stack.outputs.bastion_node_ip }}
+          BASTION_INSTANCE_ID: ${{ steps.create-cf-stack.outputs.bastion_instance_id }}
+          NGINX_INSTANCE_ID: ${{ steps.create-cf-stack.outputs.nginx_instance_id }}
+          THUNDER_INSTANCE_ID: ${{ steps.create-cf-stack.outputs.thunder_instance_id }}
+          RDS_INSTANCE_ID: ${{ steps.create-cf-stack.outputs.rds_instance_id }}
+          BASTION_INSTANCE_TYPE: ${{ steps.create-cf-stack.outputs.bastion_instance_type }}
+          NGINX_INSTANCE_TYPE: ${{ steps.create-cf-stack.outputs.nginx_instance_type }}
+          THUNDER_INSTANCE_TYPE: ${{ inputs.THUNDER_INSTANCE_TYPE }}
+          DB_INSTANCE_TYPE: ${{ inputs.DB_INSTANCE_TYPE }}
+          PERF_TEST_START_TIME: ${{ steps.execute-perf-test.outputs.perf_test_start_time }}
+          CONCURRENCY: ${{ inputs.CONCURRENCY }}
+          ADDITIONAL_PARAMS: ${{ inputs.ADDITIONAL_PARAMS_TO_RUN_PERFORMANCE_SCRIPT }}
+        run: |
+          stack_name=$(echo "$STACK_ID" | awk -F/ '{print $(NF-1)}')
+
+          {
+            echo "## VM Perf Trigger — Run #${RUN_NUMBER}"
+            echo ""
+            echo "**Status:** Kickoff complete. JMeter is running detached on the bastion."
+            echo "**Verification:** \`RUNNING\` (process confirmed on bastion after 20s)."
+            echo ""
+            echo "> AWS resources are still running. Tear them down manually when the test is done — see **Cleanup** below."
+            echo ">"
+            echo "> Cancelling THIS workflow does NOT stop the running test. To stop the test early, see **Cancel test early** below."
+            echo ""
+            echo "### Test handles"
+            echo ""
+            echo "| Item | Value |"
+            echo "|-|-|"
+            echo "| Stack name | \`${stack_name}\` |"
+            echo "| Region | \`us-west-1\` |"
+            echo "| Bastion IP | \`${BASTION_IP}\` |"
+            echo "| Test started (UTC) | \`${PERF_TEST_START_TIME}\` |"
+            echo "| Concurrency | \`${CONCURRENCY}\` |"
+            echo "| Additional params | \`${ADDITIONAL_PARAMS}\` |"
+            echo "| PEM key on S3 | \`s3://performance-thunder/keys/thunder-perf-test.pem\` |"
+            echo "| results.zip on bastion | \`/home/ubuntu/results.zip\` (created when JMeter finishes) |"
+            echo "| Live log on bastion | \`/home/ubuntu/run.log\` |"
+            echo ""
+            echo "### Instance IDs"
+            echo ""
+            echo "| Role | Instance ID | Type | Console |"
+            echo "|-|-|-|-|"
+            echo "| Bastion | \`${BASTION_INSTANCE_ID}\` | ${BASTION_INSTANCE_TYPE} | [EC2 → Monitoring](https://us-west-1.console.aws.amazon.com/ec2/home?region=us-west-1#InstanceDetails:instanceId=${BASTION_INSTANCE_ID}) |"
+            echo "| Nginx   | \`${NGINX_INSTANCE_ID}\` | ${NGINX_INSTANCE_TYPE} | [EC2 → Monitoring](https://us-west-1.console.aws.amazon.com/ec2/home?region=us-west-1#InstanceDetails:instanceId=${NGINX_INSTANCE_ID}) |"
+            echo "| Thunder | \`${THUNDER_INSTANCE_ID}\` | ${THUNDER_INSTANCE_TYPE} | [EC2 → Monitoring](https://us-west-1.console.aws.amazon.com/ec2/home?region=us-west-1#InstanceDetails:instanceId=${THUNDER_INSTANCE_ID}) |"
+            echo "| RDS     | \`${RDS_INSTANCE_ID}\` | ${DB_INSTANCE_TYPE} | [RDS → Monitoring](https://us-west-1.console.aws.amazon.com/rds/home?region=us-west-1#database:id=${RDS_INSTANCE_ID}) |"
+            echo ""
+            echo "### Fetch the PEM key (once per machine)"
+            echo ""
+            echo '```bash'
+            echo "aws s3 cp s3://performance-thunder/keys/thunder-perf-test.pem ./key.pem"
+            echo "chmod 400 ./key.pem"
+            echo '```'
+            echo ""
+            echo "### Watch progress live"
+            echo ""
+            echo '```bash'
+            echo "ssh -i ./key.pem -o StrictHostKeyChecking=no ubuntu@${BASTION_IP} \\"
+            echo "  tail -f /home/ubuntu/run.log"
+            echo '```'
+            echo ""
+            echo "### Health check (run periodically if you're unsure)"
+            echo ""
+            echo '```bash'
+            echo "ssh -i ./key.pem -o StrictHostKeyChecking=no ubuntu@${BASTION_IP} \\"
+            echo "  'echo \"process: \$(pgrep -f run-performance-tests || echo DEAD)\"; echo \"log last modified: \$(stat -c %y /home/ubuntu/run.log)\"'"
+            echo '```'
+            echo ""
+            echo "If \`process: DEAD\` and \`run.log\` hasn't been touched in >5 min, the test crashed. Retrieve \`run.log\` for diagnosis, then tear down the stack."
+            echo ""
+            echo "### Retrieve results when done"
+            echo ""
+            echo '```bash'
+            echo "scp -i ./key.pem ubuntu@${BASTION_IP}:/home/ubuntu/results.zip ."
+            echo "unzip results.zip"
+            echo '```'
+            echo ""
+            echo "### View CloudWatch metrics"
+            echo ""
+            echo "Click any **Monitoring** link in the instance table above. Set the time range to start at \`${PERF_TEST_START_TIME}\` and end at the time \`results.zip\` appeared on the bastion."
+            echo ""
+            echo "### Cancel test early"
+            echo ""
+            echo '```bash'
+            echo "ssh -i ./key.pem ubuntu@${BASTION_IP} 'pkill -f run-performance-tests.sh'"
+            echo '```'
+            echo ""
+            echo "Then follow **Cleanup** below to delete the stack."
+            echo ""
+            echo "### Cleanup"
+            echo ""
+            echo "**Option 1 — AWS Console:** [CloudFormation → ${stack_name}](https://us-west-1.console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/stackinfo?stackId=${stack_name}) → Delete"
+            echo ""
+            echo "**Option 2 — CLI:**"
+            echo ""
+            echo '```bash'
+            echo "aws cloudformation delete-stack --stack-name ${stack_name} --region us-west-1"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/perf-scripts/common/start-performance.sh
+++ b/perf-scripts/common/start-performance.sh
@@ -231,6 +231,20 @@ echo ""
 echo "Running performance tests..."
 echo "============================================"
 scp_bastion_cmd "run-performance-tests.sh" "/home/ubuntu/workspace/jmeter"
+
+# Detached mode: launch JMeter in background on the bastion and exit early.
+# When DETACHED_RUN is unset, the script continues on the existing synchronous path below.
+if [[ -n "${DETACHED_RUN:-}" ]]; then
+    echo ""
+    echo "Detached mode: launching JMeter in background on the bastion..."
+    echo "============================================"
+    ssh -i "$key_file" -o StrictHostKeyChecking=no -o ConnectTimeout=30 \
+        ubuntu@"$bastion_node_ip" \
+        "chmod +x /home/ubuntu/workspace/jmeter/run-performance-tests.sh && nohup /home/ubuntu/workspace/jmeter/run-performance-tests.sh -p 443 ${run_performance_tests_options[*]} </dev/null >/home/ubuntu/run.log 2>&1 &"
+    echo "Detached run launched. Skipping foreground JMeter execution and result collection."
+    exit 0
+fi
+
 ssh_bastion_cmd "./workspace/jmeter/run-performance-tests.sh -p 443 ${run_performance_tests_options[*]}"
 
 echo ""


### PR DESCRIPTION
## Purpose

This pull request introduces support for running VM performance tests in detached mode, allowing tests to be started on a remote bastion host without waiting for their completion. The main changes include adding a new script to trigger detached performance tests and updating the performance test runner to handle this new mode.

**Detached performance test execution:**

* Added a new script, `.github/scripts/vm-perf-trigger-script.sh`, which sets up and kicks off VM performance tests on AWS in detached mode. This script prepares the environment, constructs the command with all necessary parameters, and launches the test without waiting for it to finish.
* Updated `perf-scripts/common/start-performance.sh` to support detached mode by checking for the `DETACHED_RUN` environment variable. When set, the script launches JMeter in the background on the bastion host using `nohup`, skips foreground execution and result collection, and exits early.