### PR TITLE
Add collecting perf results for detached mode

### DIFF
--- a/.github/scripts/vm-perf-collect-script.sh
+++ b/.github/scripts/vm-perf-collect-script.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# ----------------------------------------------------------------------------
+# Download results.zip from the bastion via rsync (resumable + verified) and
+# generate summary artifacts (summary.csv, summary.md).
+#
+# Required env:
+#   WORKSPACE            - GHA workspace (used to locate perf-scripts tree).
+#   DEPLOYMENT           - e.g. single-node.
+#   BASTION_IP           - bastion public IP.
+#   KEY_FILE             - path to PEM.
+#   MANIFEST_DIR         - path to the downloaded manifest artifact directory
+#                          (contains manifest.json + cf-test-metadata.json).
+#   RESULTS_DIR_NAME     - name of the results-* dir to create (must start with "results-"
+#                          to match downstream glob patterns).
+#
+# The rsync retry loop handles multi-GB transfers over unstable networks:
+#   --partial            keep partial file on failure for the next attempt to resume from
+#   --append-verify      resume by appending, then verify the whole file end-to-end
+#   --timeout=180        fail an idle rsync within 3min so the retry can kick in
+#   -e "ssh ..."         controls the ssh transport (keepalives, connect timeout)
+# 3 attempts with exponential backoff. Resume + verify means each retry only
+# re-transfers what wasn't already delivered.
+# ----------------------------------------------------------------------------
+
+set -euo pipefail
+
+: "${WORKSPACE:?WORKSPACE must be set}"
+: "${DEPLOYMENT:?DEPLOYMENT must be set}"
+: "${BASTION_IP:?BASTION_IP must be set}"
+: "${KEY_FILE:?KEY_FILE must be set}"
+: "${MANIFEST_DIR:?MANIFEST_DIR must be set}"
+: "${RESULTS_DIR_NAME:?RESULTS_DIR_NAME must be set}"
+
+DEPLOYMENT_DIR="$WORKSPACE/perf-scripts/$DEPLOYMENT"
+RESULTS_DIR="$DEPLOYMENT_DIR/$RESULTS_DIR_NAME"
+
+echo "Preparing results directory: $RESULTS_DIR"
+mkdir -p "$RESULTS_DIR"
+
+echo ""
+echo "Copying CF test metadata into results directory..."
+if [[ ! -f "$MANIFEST_DIR/cf-test-metadata.json" ]]; then
+    echo "ERROR: cf-test-metadata.json not present in manifest artifact." >&2
+    exit 1
+fi
+cp "$MANIFEST_DIR/cf-test-metadata.json" "$RESULTS_DIR/cf-test-metadata.json"
+
+echo ""
+echo "Extracting Thunder Performance Distribution into $RESULTS_DIR"
+tar -xf "$DEPLOYMENT_DIR"/target/performance-thunder-singlenode-*.tar.gz -C "$RESULTS_DIR"
+
+# ---------------------------------------------------------------------------
+# Download results.zip from bastion — resumable + verified, with retry
+# ---------------------------------------------------------------------------
+echo ""
+echo "Downloading results.zip from bastion via rsync..."
+echo "  source: ubuntu@${BASTION_IP}:/home/ubuntu/results.zip"
+echo "  target: ${RESULTS_DIR}/results.zip"
+
+ssh_transport="ssh -i \"$KEY_FILE\" -o StrictHostKeyChecking=no -o ServerAliveInterval=15 -o ServerAliveCountMax=8 -o ConnectTimeout=30"
+
+download_ok=0
+for attempt in 1 2 3; do
+    echo ""
+    echo "rsync attempt $attempt/3..."
+    if rsync -avP --partial --append-verify --timeout=180 \
+        -e "$ssh_transport" \
+        "ubuntu@${BASTION_IP}:/home/ubuntu/results.zip" \
+        "$RESULTS_DIR/results.zip"; then
+        echo "rsync succeeded on attempt $attempt."
+        download_ok=1
+        break
+    fi
+    echo "rsync attempt $attempt failed (exit $?)."
+    if [[ $attempt -lt 3 ]]; then
+        backoff=$((attempt * 30))
+        echo "Backing off ${backoff}s before retry..."
+        sleep "$backoff"
+    fi
+done
+
+if [[ $download_ok -ne 1 ]]; then
+    echo "ERROR: rsync failed after 3 attempts." >&2
+    exit 1
+fi
+
+if [[ ! -f "$RESULTS_DIR/results.zip" ]]; then
+    echo "ERROR: results.zip not present after rsync (unexpected)." >&2
+    exit 1
+fi
+
+result_size=$(stat -c %s "$RESULTS_DIR/results.zip")
+echo "Downloaded results.zip: $result_size bytes"
+
+# ---------------------------------------------------------------------------
+# Extract results and generate summary artifacts
+# ---------------------------------------------------------------------------
+echo ""
+echo "Creating summary.csv..."
+echo "============================================"
+cd "$RESULTS_DIR"
+unzip -q results.zip
+wget -q http://sourceforge.net/projects/gcviewer/files/gcviewer-1.35.jar/download -O gcviewer.jar
+
+"$RESULTS_DIR"/jmeter/create-summary-csv.sh -d results -n "WSO2 Thunder" -p wso2thunder -c "Heap Size" \
+    -c "Concurrent Users" -r "([0-9]+[a-zA-Z])_heap" -r "([0-9]+)_users" -i -l -k 1 -g gcviewer.jar
+
+echo ""
+echo "Creating summary results markdown file..."
+./jmeter/create-summary-markdown.py --json-files cf-test-metadata.json results/test-metadata.json --column-names \
+    "Concurrent Users" "95th Percentile of Response Time (ms)"
+
+# Cleanup intermediate files — matches start-performance.sh's tail behavior so that
+# the uploaded artifact structure is consistent with the current single-workflow flow.
+rm -rf cf-test-metadata.json cloudformation/ common/ gcviewer.jar is/ jmeter/ jtl-splitter/ netty-service/ payloads/ sar/ setup/ results/ thunder/restart-thunder.sh summary/
+
+echo ""
+echo "Collect script complete."
+echo "============================================"

--- a/.github/workflows/vm-perf-collect.yml
+++ b/.github/workflows/vm-perf-collect.yml
@@ -1,0 +1,294 @@
+name: VM Performance Test - Collect Results
+
+# Downloads results.zip from the bastion of a completed vm-perf-trigger run,
+# generates the summary artifacts, collects CloudWatch metrics, publishes the
+# job summary, tears down the CloudFormation stack, and uploads GHA artifacts.
+
+on:
+  workflow_dispatch:
+    inputs:
+      TRIGGER_RUN_NUMBER:
+        description: 'Run number of the vm-perf-trigger workflow whose results to collect'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read   # needed for `gh run download` from another workflow run
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    env:
+      RESOURCES_DIR: ${{ github.workspace }}/resources
+      MANIFEST_DIR: ${{ github.workspace }}/_manifest
+    steps:
+      - name: Validate input
+        run: |
+          run_num="${{ inputs.TRIGGER_RUN_NUMBER }}"
+          if ! [[ "$run_num" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::TRIGGER_RUN_NUMBER must be a positive integer (got: '${run_num}')"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-1
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Locate trigger workflow run
+        id: locate-trigger
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRIGGER_RUN_NUMBER: ${{ inputs.TRIGGER_RUN_NUMBER }}
+        run: |
+          # Find the trigger workflow run that has the requested `github.run_number`.
+          # We look at recent workflow_dispatch runs of vm-perf-trigger.yml.
+          run_id=$(gh run list \
+            --workflow=vm-perf-trigger.yml \
+            --limit 100 \
+            --json databaseId,number,conclusion \
+            --jq ".[] | select(.number==${TRIGGER_RUN_NUMBER}) | .databaseId" \
+            | head -1)
+          if [[ -z "$run_id" ]]; then
+            echo "::error::Could not find a vm-perf-trigger run with run number ${TRIGGER_RUN_NUMBER}. Was the run started via vm-perf-trigger.yml, and within the last 100 runs?"
+            exit 1
+          fi
+          echo "Located trigger run id: $run_id"
+          echo "trigger_run_id=$run_id" >> "$GITHUB_OUTPUT"
+
+      - name: Download trigger manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRIGGER_RUN_ID: ${{ steps.locate-trigger.outputs.trigger_run_id }}
+          TRIGGER_RUN_NUMBER: ${{ inputs.TRIGGER_RUN_NUMBER }}
+        run: |
+          mkdir -p "$MANIFEST_DIR"
+          if ! gh run download "$TRIGGER_RUN_ID" \
+                 --name "manifest-${TRIGGER_RUN_NUMBER}" \
+                 --dir "$MANIFEST_DIR"; then
+            echo "::error::Failed to download manifest-${TRIGGER_RUN_NUMBER} artifact from trigger run ${TRIGGER_RUN_ID}. Artifact may be expired (>90d) or the trigger workflow may have failed before uploading it."
+            exit 1
+          fi
+          if [[ ! -f "$MANIFEST_DIR/manifest.json" ]]; then
+            echo "::error::manifest.json missing from downloaded artifact."
+            exit 1
+          fi
+          if [[ ! -f "$MANIFEST_DIR/cf-test-metadata.json" ]]; then
+            echo "::error::cf-test-metadata.json missing from downloaded artifact."
+            exit 1
+          fi
+          echo "Manifest downloaded:"
+          ls -la "$MANIFEST_DIR"
+
+      - name: Parse manifest into env vars
+        id: parse-manifest
+        run: |
+          m="$MANIFEST_DIR/manifest.json"
+          # Each entry is: <output_key>|<jq_path>|<required?>
+          # jq -r produces plain strings; a "null" or empty result on a required field aborts.
+          fields=(
+            "stack_name|.stack_name|1"
+            "stack_id|.stack_id|1"
+            "bastion_ip|.bastion_ip|1"
+            "bastion_id|.instance_ids.bastion|1"
+            "nginx_id|.instance_ids.nginx|0"
+            "thunder_id|.instance_ids.thunder|1"
+            "rds_id|.instance_ids.rds|1"
+            "bastion_type|.instance_types.bastion|0"
+            "nginx_type|.instance_types.nginx|0"
+            "thunder_type|.instance_types.thunder|0"
+            "db_type|.instance_types.rds|0"
+            "perf_test_start_time|.perf_test_start_time|1"
+            "deployment|.inputs.DEPLOYMENT|1"
+            "concurrency|.inputs.CONCURRENCY|0"
+            "thunder_pack_url|.inputs.THUNDER_PACK_URL|0"
+            "repo_ref|.inputs.REPO_REF|0"
+          )
+          for entry in "${fields[@]}"; do
+            IFS='|' read -r key path required <<< "$entry"
+            val=$(jq -r "$path" "$m")
+            if [[ "$val" == "null" ]]; then val=""; fi
+            if [[ "$required" == "1" && -z "$val" ]]; then
+              echo "::error::Manifest is missing required field: $key ($path)"
+              exit 1
+            fi
+            echo "${key}=${val}" >> "$GITHUB_OUTPUT"
+          done
+          echo "Manifest parsed successfully."
+
+      - name: Download PEM key
+        run: |
+          mkdir -p "$RESOURCES_DIR"
+          aws s3 cp s3://performance-thunder/keys/thunder-perf-test.pem \
+            "$RESOURCES_DIR/thunder-perf-test.pem" --only-show-errors --no-progress
+          chmod 400 "$RESOURCES_DIR/thunder-perf-test.pem"
+
+      - name: Verify stack still exists
+        env:
+          STACK_NAME: ${{ steps.parse-manifest.outputs.stack_name }}
+        run: |
+          if ! aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region us-west-1 >/dev/null 2>&1; then
+            echo "::error::CloudFormation stack '$STACK_NAME' does not exist (already deleted?). Nothing to collect."
+            exit 1
+          fi
+          echo "Stack '$STACK_NAME' exists."
+
+      - name: Precheck bastion — test finished, results.zip present
+        id: precheck
+        timeout-minutes: 3
+        env:
+          BASTION_IP: ${{ steps.parse-manifest.outputs.bastion_ip }}
+        run: |
+          set +x
+          precheck_output=$(ssh -n -i "${RESOURCES_DIR}/thunder-perf-test.pem" \
+            -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
+            -o ServerAliveInterval=10 -o ServerAliveCountMax=3 \
+            ubuntu@"${BASTION_IP}" \
+            'if pgrep -f run-performance-tests.sh >/dev/null; then
+               echo STATUS=RUNNING
+               exit 0
+             fi
+             if [[ ! -f /home/ubuntu/results.zip ]]; then
+               echo STATUS=NO_RESULTS
+               echo "--- run.log tail ---"
+               tail -n 30 /home/ubuntu/run.log 2>/dev/null || echo "(no run.log)"
+               exit 0
+             fi
+             end_epoch=$(stat -c %Y /home/ubuntu/results.zip)
+             end_iso=$(date -u -d @${end_epoch} +%Y-%m-%dT%H:%M:%SZ)
+             size=$(stat -c %s /home/ubuntu/results.zip)
+             echo STATUS=READY
+             echo END_TIME=${end_iso}
+             echo SIZE=${size}')
+
+          # Redact any accidental AWS access-key pattern before printing.
+          echo "$precheck_output" | sed -E 's/AKIA[0-9A-Z]{16}/AKIA****REDACTED****/g'
+
+          status=$(echo "$precheck_output" | grep '^STATUS=' | head -1 | cut -d= -f2)
+          case "$status" in
+            READY)
+              end_time=$(echo "$precheck_output" | grep '^END_TIME=' | cut -d= -f2)
+              size=$(echo "$precheck_output" | grep '^SIZE=' | cut -d= -f2)
+              echo "perf_test_end_time=$end_time" >> "$GITHUB_OUTPUT"
+              echo "results_size=$size" >> "$GITHUB_OUTPUT"
+              echo "Bastion reports test READY. results.zip is ${size} bytes, finished at ${end_time}."
+              ;;
+            RUNNING)
+              echo "::error::JMeter is still running on the bastion. Wait for it to finish before running collect."
+              exit 1
+              ;;
+            NO_RESULTS)
+              echo "::error::JMeter is not running and results.zip does not exist — the test likely crashed. See run.log tail above."
+              exit 1
+              ;;
+            *)
+              echo "::error::Unexpected precheck status: '$status'"
+              exit 1
+              ;;
+          esac
+
+      - name: Build Performance Tests
+        env:
+          DEPLOYMENT: ${{ steps.parse-manifest.outputs.deployment }}
+        run: |
+          cd $GITHUB_WORKSPACE/perf-scripts/$DEPLOYMENT
+          echo "Building performance test project: $DEPLOYMENT..."
+          mvn -q clean install
+
+      - name: Collect results and generate summary
+        id: collect
+        env:
+          WORKSPACE: ${{ github.workspace }}
+          DEPLOYMENT: ${{ steps.parse-manifest.outputs.deployment }}
+          BASTION_IP: ${{ steps.parse-manifest.outputs.bastion_ip }}
+          KEY_FILE: ${{ github.workspace }}/resources/thunder-perf-test.pem
+          MANIFEST_DIR: ${{ github.workspace }}/_manifest
+          # The results dir name uses the trigger run number so multiple collects don't collide.
+          RESULTS_DIR_NAME: results-trigger-${{ inputs.TRIGGER_RUN_NUMBER }}
+        run: |
+          chmod +x .github/scripts/vm-perf-collect-script.sh
+          bash .github/scripts/vm-perf-collect-script.sh
+
+      - name: Collect CloudWatch Metrics
+        if: always() && steps.parse-manifest.outputs.thunder_id != ''
+        env:
+          WORKSPACE: ${{ github.workspace }}
+          DEPLOYMENT: ${{ steps.parse-manifest.outputs.deployment }}
+          PERF_TEST_START_TIME: ${{ steps.parse-manifest.outputs.perf_test_start_time }}
+          PERF_TEST_END_TIME: ${{ steps.precheck.outputs.perf_test_end_time }}
+          BASTION_INSTANCE_ID: ${{ steps.parse-manifest.outputs.bastion_id }}
+          NGINX_INSTANCE_ID: ${{ steps.parse-manifest.outputs.nginx_id }}
+          THUNDER_INSTANCE_ID: ${{ steps.parse-manifest.outputs.thunder_id }}
+          RDS_INSTANCE_ID: ${{ steps.parse-manifest.outputs.rds_id }}
+        run: |
+          pip install -q matplotlib
+          chmod +x .github/scripts/collect-cloudwatch-metrics.sh
+          bash .github/scripts/collect-cloudwatch-metrics.sh
+          python3 .github/scripts/generate-metrics-charts.py || echo "WARN: Chart generation failed."
+
+      - name: Publish Job Summary
+        if: always()
+        env:
+          WORKSPACE: ${{ github.workspace }}
+          DEPLOYMENT: ${{ steps.parse-manifest.outputs.deployment }}
+          BUILD_NUMBER: ${{ inputs.TRIGGER_RUN_NUMBER }}
+          TIMESTAMP: ${{ steps.parse-manifest.outputs.perf_test_start_time }}
+          THUNDER_PACK_URL: ${{ steps.parse-manifest.outputs.thunder_pack_url }}
+          THUNDER_INSTANCE_TYPE: ${{ steps.parse-manifest.outputs.thunder_type }}
+          NGINX_INSTANCE_TYPE: ${{ steps.parse-manifest.outputs.nginx_type }}
+          BASTION_INSTANCE_TYPE: ${{ steps.parse-manifest.outputs.bastion_type }}
+          DB_INSTANCE_TYPE: ${{ steps.parse-manifest.outputs.db_type }}
+          DB_TYPE: 'postgres'
+          CONCURRENCY: ${{ steps.parse-manifest.outputs.concurrency }}
+          BASTION_INSTANCE_ID: ${{ steps.parse-manifest.outputs.bastion_id }}
+          NGINX_INSTANCE_ID: ${{ steps.parse-manifest.outputs.nginx_id }}
+          THUNDER_INSTANCE_ID: ${{ steps.parse-manifest.outputs.thunder_id }}
+          RDS_INSTANCE_ID: ${{ steps.parse-manifest.outputs.rds_id }}
+          REPO_REF: ${{ steps.parse-manifest.outputs.repo_ref }}
+        run: |
+          python3 .github/scripts/generate-job-summary.py || echo "WARN: Job summary generation failed."
+
+      - name: Delete CloudFormation Stack
+        if: always() && steps.parse-manifest.outputs.stack_id != ''
+        env:
+          STACK_ID: ${{ steps.parse-manifest.outputs.stack_id }}
+        run: |
+          chmod +x .github/scripts/delete-cf-stack.sh
+          bash .github/scripts/delete-cf-stack.sh
+
+      - name: Upload summary artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-test-results-${{ inputs.TRIGGER_RUN_NUMBER }}
+          path: |
+            ${{ github.workspace }}/perf-scripts/${{ steps.parse-manifest.outputs.deployment }}/results-*/summary.csv
+            ${{ github.workspace }}/perf-scripts/${{ steps.parse-manifest.outputs.deployment }}/results-*/summary.md
+            ${{ github.workspace }}/perf-scripts/${{ steps.parse-manifest.outputs.deployment }}/results-*/instance-ids.txt
+            ${{ github.workspace }}/perf-scripts/${{ steps.parse-manifest.outputs.deployment }}/results-*/cloudwatch/**
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Upload full results artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-test-results-full-${{ inputs.TRIGGER_RUN_NUMBER }}
+          path: ${{ github.workspace }}/perf-scripts/${{ steps.parse-manifest.outputs.deployment }}/results-*
+          retention-days: 30
+          if-no-files-found: warn

--- a/.github/workflows/vm-perf-trigger.yml
+++ b/.github/workflows/vm-perf-trigger.yml
@@ -328,8 +328,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: manifest-${{ github.run_number }}
-          path: ${{ github.workspace }}/manifest.json
+          # cf-test-metadata.json is written by create-cf-stack.sh; collect uses it
+          # in create-summary-markdown.py to render instance types in the report.
+          path: |
+            ${{ github.workspace }}/manifest.json
+            ${{ github.workspace }}/cf-test-metadata.json
           retention-days: 90
+          if-no-files-found: error
 
       - name: Publish trigger summary
         env:
@@ -359,6 +364,18 @@ jobs:
             echo "> AWS resources are still running. Tear them down manually when the test is done — see **Cleanup** below."
             echo ">"
             echo "> Cancelling THIS workflow does NOT stop the running test. To stop the test early, see **Cancel test early** below."
+            echo ""
+            echo "### When the test finishes"
+            echo ""
+            echo "**Automated (recommended)** — one command retrieves results, generates the summary, tears down the CloudFormation stack, and uploads GHA artifacts:"
+            echo ""
+            echo '```bash'
+            echo "gh workflow run vm-perf-collect.yml -f TRIGGER_RUN_NUMBER=${RUN_NUMBER}"
+            echo '```'
+            echo ""
+            echo "You can also click **Actions → VM Performance Test - Collect Results → Run workflow** and paste \`${RUN_NUMBER}\` as the trigger run number."
+            echo ""
+            echo "**Manual** — do it by hand (see the sections below for the individual steps: retrieve results, view metrics, tear down stack)."
             echo ""
             echo "### Test handles"
             echo ""
@@ -406,7 +423,9 @@ jobs:
             echo ""
             echo "If \`process: DEAD\` and \`run.log\` hasn't been touched in >5 min, the test crashed. Retrieve \`run.log\` for diagnosis, then tear down the stack."
             echo ""
-            echo "### Retrieve results when done"
+            echo "### Retrieve results when done (manual)"
+            echo ""
+            echo "For the automated flow see **When the test finishes** above."
             echo ""
             echo '```bash'
             echo "scp -i ./key.pem ubuntu@${BASTION_IP}:/home/ubuntu/results.zip ."
@@ -425,7 +444,9 @@ jobs:
             echo ""
             echo "Then follow **Cleanup** below to delete the stack."
             echo ""
-            echo "### Cleanup"
+            echo "### Cleanup (manual)"
+            echo ""
+            echo "The automated \`vm-perf-collect.yml\` workflow tears down the stack for you (with \`if: always()\`). Only use these commands if you're doing a manual flow."
             echo ""
             echo "**Option 1 — AWS Console:** [CloudFormation → ${stack_name}](https://us-west-1.console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/stackinfo?stackId=${stack_name}) → Delete"
             echo ""

--- a/perf-scripts/common/start-performance.sh
+++ b/perf-scripts/common/start-performance.sh
@@ -234,13 +234,21 @@ scp_bastion_cmd "run-performance-tests.sh" "/home/ubuntu/workspace/jmeter"
 
 # Detached mode: launch JMeter in background on the bastion and exit early.
 # When DETACHED_RUN is unset, the script continues on the existing synchronous path below.
+#
+# Detach mechanics:
+#   - `ssh -n` disconnects the local stdin so ssh doesn't wait on it.
+#   - `setsid --fork` on the remote side forks JMeter into a new session that is
+#     detached from ssh's channel; the immediate parent that ssh is watching exits
+#     right after the fork, so the ssh call returns while JMeter keeps running.
+#   - `</dev/null >run.log 2>&1` gives the child its own stdio so no fd traces back
+#     to ssh's pipe.
 if [[ -n "${DETACHED_RUN:-}" ]]; then
     echo ""
     echo "Detached mode: launching JMeter in background on the bastion..."
     echo "============================================"
-    ssh -i "$key_file" -o StrictHostKeyChecking=no -o ConnectTimeout=30 \
+    ssh -n -i "$key_file" -o StrictHostKeyChecking=no -o ConnectTimeout=30 \
         ubuntu@"$bastion_node_ip" \
-        "chmod +x /home/ubuntu/workspace/jmeter/run-performance-tests.sh && nohup /home/ubuntu/workspace/jmeter/run-performance-tests.sh -p 443 ${run_performance_tests_options[*]} </dev/null >/home/ubuntu/run.log 2>&1 &"
+        "chmod +x /home/ubuntu/workspace/jmeter/run-performance-tests.sh && setsid --fork /home/ubuntu/workspace/jmeter/run-performance-tests.sh -p 443 ${run_performance_tests_options[*]} </dev/null >/home/ubuntu/run.log 2>&1"
     echo "Detached run launched. Skipping foreground JMeter execution and result collection."
     exit 0
 fi


### PR DESCRIPTION
## Purpose
This pull request introduces a new automated workflow for collecting and summarizing VM performance test results, along with several supporting improvements to streamline the performance testing process. The changes automate the retrieval and summarization of test artifacts, enhance reliability and documentation, and clarify the manual versus automated flows for users.

**Key changes include:**

### New Automated Collection Workflow

* Added `.github/workflows/vm-perf-collect.yml`, a comprehensive workflow that, given a trigger run number, downloads test results from the bastion, generates summary artifacts, collects CloudWatch metrics, publishes a job summary, tears down the CloudFormation stack, and uploads artifacts to GitHub Actions. This workflow enables a fully automated and reproducible results collection process.

* Introduced `.github/scripts/vm-perf-collect-script.sh`, a robust Bash script that handles resumable and verified downloading of large results files via `rsync`, generates summary CSV and markdown reports, and cleans up intermediate files. The script is designed for reliability over unstable networks and integrates with the new workflow.

### Improvements to Artifact Handling and Documentation

* Updated `vm-perf-trigger.yml` to include both `manifest.json` and `cf-test-metadata.json` in the uploaded manifest artifact, ensuring all necessary metadata is available for the automated collection workflow.

* Enhanced the job summary in `vm-perf-trigger.yml` to clearly document the new automated collection flow, providing users with copy-paste commands and distinguishing between automated and manual result retrieval and cleanup steps. [[1]](diffhunk://#diff-34901e2bcc83fff5080e02b97f2dcaeda2527a52f8302de21b791f9b4908a938R368-R379) [[2]](diffhunk://#diff-34901e2bcc83fff5080e02b97f2dcaeda2527a52f8302de21b791f9b4908a938L409-R428) [[3]](diffhunk://#diff-34901e2bcc83fff5080e02b97f2dcaeda2527a52f8302de21b791f9b4908a938L428-R449)

### Reliability and Usability Enhancements

* Improved the detached JMeter execution mode in `perf-scripts/common/start-performance.sh` by using `ssh -n` and `setsid --fork` to ensure the background process is fully detached from the SSH session, increasing reliability for long-running tests.