### PR TITLE
Authenticate test-data seeding with an admin token

### DIFF
--- a/perf-scripts/common/deployment/setup/update-thunder-conf.sh
+++ b/perf-scripts/common/deployment/setup/update-thunder-conf.sh
@@ -116,7 +116,10 @@ echo "-------------------------------------------"
 cd "$carbon_home"
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 LOG_FILE="thunder_${TIMESTAMP}.log"
-SKIP_SECURITY=true bash start.sh > "$LOG_FILE" 2>&1 &
+# Default resources (admin user, default OU, Console app) are seeded in-process by
+# setup.sh above. Perf test data is seeded with an admin token (see get_admin_token
+# in perf-test-thunder.sh).
+bash start.sh > "$LOG_FILE" 2>&1 &
 cd "../"
 echo "Waiting 30s for Thunder server to start..."
 sleep 30s

--- a/perf-scripts/common/jmeter/perf-test-thunder.sh
+++ b/perf-scripts/common/jmeter/perf-test-thunder.sh
@@ -84,6 +84,17 @@ idpCount=1
 userCount=1000
 deployment=""
 
+# Admin credentials used to obtain a token for seeding test data via the
+# management APIs. These match Thunder's in-process bootstrap defaults.
+admin_username="admin"
+admin_password="admin"
+# OAuth2 client and redirect URI seeded by Thunder's bootstrap for the Console
+# app. The redirect URI is derived from the server hostname:port in
+# deployment.yaml (thunder.wso2.com:8090) and must match exactly.
+admin_client_id="CONSOLE"
+admin_redirect_uri="https://thunder.wso2.com:8090/console"
+admin_scope="system"
+
 # Use delays inside tests to mimic user input
 use_delay=true
 
@@ -419,6 +430,121 @@ function print_durations() {
     printf "Script execution time: %s\n" "$(format_time $(measure_time "$test_start_time"))"
 }
 
+# Maximum tolerated error percentage for a test-data seeding run before the whole
+# performance test is aborted. Seeding into a fresh database should be ~0%.
+seed_max_err_pct=1
+
+# Obtain an admin access token for seeding test data via Thunder's management APIs.
+#
+# The management endpoints require a Bearer token with the `system` scope. This
+# drives the app-native authorization-code + PKCE flow against the bootstrapped
+# Console client to mint such a token.
+#
+# All diagnostics go to stderr; only the access token is written to stdout so the
+# caller can capture it with: token="$(get_admin_token)".
+function get_admin_token() {
+
+    local base="https://${lb_host}:${is_port}"
+
+    # 1. PKCE parameters (base64url, no padding).
+    local code_verifier code_challenge
+    code_verifier=$(openssl rand -base64 32 | tr '+/' '-_' | tr -d '=\n')
+    code_challenge=$(printf '%s' "$code_verifier" | openssl dgst -sha256 -binary \
+        | openssl base64 | tr '+/' '-_' | tr -d '=\n')
+
+    # 2. Initiate the authorization request; capture the 302 Location header.
+    local location
+    location=$(curl -sk -o /dev/null -D - -G "${base}/oauth2/authorize" \
+        --data-urlencode "client_id=${admin_client_id}" \
+        --data-urlencode "redirect_uri=${admin_redirect_uri}" \
+        --data-urlencode "response_type=code" \
+        --data-urlencode "scope=${admin_scope}" \
+        --data-urlencode "state=perf" \
+        --data-urlencode "code_challenge=${code_challenge}" \
+        --data-urlencode "code_challenge_method=S256" \
+        | grep -i '^location:' | tail -1 | sed 's/^[Ll]ocation:[[:space:]]*//' | tr -d '\r')
+
+    local auth_id execution_id
+    auth_id=$(printf '%s' "$location" | sed -n 's/.*[?&]authId=\([^&]*\).*/\1/p')
+    execution_id=$(printf '%s' "$location" | sed -n 's/.*[?&]executionId=\([^&]*\).*/\1/p')
+    if [[ -z "$auth_id" || -z "$execution_id" ]]; then
+        echo "ERROR: Failed to obtain admin token: no authId/executionId from /oauth2/authorize." >&2
+        echo "       Location header was: '${location}'" >&2
+        exit 1
+    fi
+
+    # 3. Drive the flow to the credentials prompt.
+    local step1 challenge_token
+    step1=$(curl -sk -X POST "${base}/flow/execute" -H 'Content-Type: application/json' \
+        -d "{\"executionId\":\"${execution_id}\"}")
+    challenge_token=$(printf '%s' "$step1" | jq -r '.challengeToken // empty')
+
+    # 4. Submit admin credentials; expect a completed flow with a signed assertion.
+    local step2 flow_status assertion
+    step2=$(curl -sk -X POST "${base}/flow/execute" -H 'Content-Type: application/json' \
+        -d "{\"executionId\":\"${execution_id}\",\"action\":\"action_001\",\"challengeToken\":\"${challenge_token}\",\"inputs\":{\"username\":\"${admin_username}\",\"password\":\"${admin_password}\"}}")
+    flow_status=$(printf '%s' "$step2" | jq -r '.flowStatus // empty')
+    assertion=$(printf '%s' "$step2" | jq -r '.assertion // empty')
+    if [[ "$flow_status" != "COMPLETE" || -z "$assertion" ]]; then
+        echo "ERROR: Admin authentication flow did not complete (status='${flow_status}')." >&2
+        echo "       Response: ${step2}" >&2
+        exit 1
+    fi
+
+    # 5. Complete authorization to obtain the authorization code.
+    local callback redirect_with_code code
+    callback=$(curl -sk -X POST "${base}/oauth2/auth/callback" -H 'Content-Type: application/json' \
+        -d "{\"authId\":\"${auth_id}\",\"assertion\":\"${assertion}\"}")
+    redirect_with_code=$(printf '%s' "$callback" | jq -r '.redirect_uri // empty')
+    code=$(printf '%s' "$redirect_with_code" | sed -n 's/.*[?&]code=\([^&]*\).*/\1/p')
+    if [[ -z "$code" ]]; then
+        echo "ERROR: Failed to obtain authorization code from /oauth2/auth/callback." >&2
+        echo "       Response: ${callback}" >&2
+        exit 1
+    fi
+
+    # 6. Exchange the code for an access token (public client -> PKCE, no secret).
+    local token_resp access_token
+    token_resp=$(curl -sk -X POST "${base}/oauth2/token" \
+        -H 'Content-Type: application/x-www-form-urlencoded' \
+        --data-urlencode "grant_type=authorization_code" \
+        --data-urlencode "code=${code}" \
+        --data-urlencode "redirect_uri=${admin_redirect_uri}" \
+        --data-urlencode "client_id=${admin_client_id}" \
+        --data-urlencode "code_verifier=${code_verifier}")
+    access_token=$(printf '%s' "$token_resp" | jq -r '.access_token // empty')
+    if [[ -z "$access_token" ]]; then
+        echo "ERROR: Failed to obtain access token from /oauth2/token." >&2
+        echo "       Response: ${token_resp}" >&2
+        exit 1
+    fi
+
+    echo "Successfully obtained admin access token for test-data seeding." >&2
+    printf '%s' "$access_token"
+}
+
+# Abort the run if a seeding script did not create its resources. JMeter exits 0
+# even when every request fails, so without this a broken bootstrap would produce
+# a green pipeline with empty benchmarks.
+function assert_seed_succeeded() {
+    local label="$1"
+    local jmeter_output="$2"
+    local err_pct
+    err_pct=$(printf '%s\n' "$jmeter_output" \
+        | grep -oE 'Err:[[:space:]]+[0-9]+ \([0-9.]+%\)' | tail -1 \
+        | grep -oE '\([0-9.]+%\)' | tr -d '()%')
+    if [[ -z "$err_pct" ]]; then
+        echo "ERROR: Could not determine seeding error rate for $label (no JMeter summary found)." >&2
+        exit 1
+    fi
+    if awk -v e="$err_pct" -v t="$seed_max_err_pct" 'BEGIN { exit !((e + 0) > (t + 0)) }'; then
+        echo "ERROR: Test data seeding failed for $label: ${err_pct}% errors (threshold ${seed_max_err_pct}%)." >&2
+        echo "       This typically means the management APIs rejected the requests (401/403)." >&2
+        exit 1
+    fi
+    echo "Seeding OK for $label: ${err_pct}% errors (threshold ${seed_max_err_pct}%)."
+}
+
 function run_jmeter_scripts() {
 
     local scripts=("$@")
@@ -435,10 +561,14 @@ function run_jmeter_scripts() {
         for param in "${jmeter_params[@]}"; do
             command+=" -J$param"
         done
-        command+=" -l test_data_store/results.jtl"
+        command+=" -l $test_data_store/results.jtl"
         echo "$command"
         echo ""
-        $command
+        local output
+        output="$($command 2>&1)" || true
+        echo "$output"
+        echo ""
+        assert_seed_succeeded "$script" "$output"
         echo ""
     done
 }
@@ -447,8 +577,11 @@ function run_test_data_scripts() {
 
     echo "Running test data setup scripts"
     echo "=========================================================================================="
+    # Seeding calls the management APIs, which require an admin token.
+    local admin_access_token
+    admin_access_token="$(get_admin_token)"
     declare -a scripts=("TestData_Thunder_Add_Applications.jmx" "TestData_Thunder_Add_Users.jmx")
-    declare -ag additional_jmeter_params=("jwtTokenUserPassword=$jwt_token_user_password" "jwtTokenClientSecret=$jwt_token_client_secret")
+    declare -ag additional_jmeter_params=("jwtTokenUserPassword=$jwt_token_user_password" "jwtTokenClientSecret=$jwt_token_client_secret" "adminAccessToken=$admin_access_token")
     run_jmeter_scripts "${scripts[@]}"
 }
 

--- a/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
+++ b/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
@@ -83,6 +83,15 @@
         </collectionProp>
       </Arguments>
       <hashTree/>
+      <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="Authorization Header Manager" enabled="true">
+        <collectionProp name="HeaderManager.headers">
+          <elementProp name="Authorization" elementType="Header">
+            <stringProp name="Header.name">Authorization</stringProp>
+            <stringProp name="Header.value">Bearer ${__P(adminAccessToken,)}</stringProp>
+          </elementProp>
+        </collectionProp>
+      </HeaderManager>
+      <hashTree/>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Create Custom Authn Flow">
         <intProp name="ThreadGroup.num_threads">1</intProp>
         <intProp name="ThreadGroup.ramp_time">1</intProp>

--- a/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Users.jmx
+++ b/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Users.jmx
@@ -69,6 +69,15 @@
         </collectionProp>
       </Arguments>
       <hashTree/>
+      <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="Authorization Header Manager" enabled="true">
+        <collectionProp name="HeaderManager.headers">
+          <elementProp name="Authorization" elementType="Header">
+            <stringProp name="Header.name">Authorization</stringProp>
+            <stringProp name="Header.value">Bearer ${__P(adminAccessToken,)}</stringProp>
+          </elementProp>
+        </collectionProp>
+      </HeaderManager>
+      <hashTree/>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Get Default OU ID" enabled="true">
         <intProp name="ThreadGroup.num_threads">1</intProp>
         <intProp name="ThreadGroup.ramp_time">1</intProp>


### PR DESCRIPTION
## Purpose

Thunder [PR #3381](https://github.com/thunder-id/thunderid/pull/3381) removed the `SKIP_SECURITY` config, so the server now always enforces authorization on the management APIs. The performance harness relied on `SKIP_SECURITY=true` to seed test data (1000 applications, 1000 users, and a custom auth flow) by calling `/flows`, `/applications`, `/user-types`, `/users`, and `/organization-units` **without any token**. After the removal, every seeding request fails with `401/403`, no resources are created, and the subsequent load scenarios run against an empty server — yet the workflow still goes **green** because JMeter continues on sample errors and nothing checks the seed's error rate.

Reference failure: [run #28923118746](https://github.com/asgardeo/thunder-performance/actions/runs/28923118746) — both `TestData_*` plans reported `Err: 1002 (100.00%)`.

## Changes

- **`get_admin_token()`** in `perf-test-thunder.sh` — drives the app-native authorization-code + PKCE flow against the bootstrapped `CONSOLE` client (`/oauth2/authorize` → `/flow/execute` ×2 → `/oauth2/auth/callback` → `/oauth2/token`) to mint a `system`-scoped admin token, passed to the seeding plans as `-JadminAccessToken`.
- **Bearer header** — both `TestData_Thunder_Add_Applications.jmx` and `TestData_Thunder_Add_Users.jmx` now send `Authorization: Bearer ${__P(adminAccessToken,)}` on all samplers (test-plan-scoped header manager).
- **`assert_seed_succeeded()`** — parses each seed run's JMeter summary and aborts the whole test (exit 1) if the error rate exceeds the threshold, so a broken bootstrap fails the pipeline loudly instead of producing empty benchmarks.
- **Removed the now-unused `SKIP_SECURITY=true`** from the Thunder start command.

The three load scenarios (`oauth/*.jmx`, `authenticate/*.jmx`) are unchanged — they hit public endpoints and only failed because seeding failed; they pass again once resources exist.

## Verification

- `bash -n` on the modified shell scripts and `xmllint` on the JMX files pass.
- Token-flow parsing and PKCE generation unit-tested standalone.
- **Pending:** an end-to-end workflow run against a current Thunder pack to confirm ~0% seeding errors and non-empty benchmarks.