### PR TITLE
Change default THUNDER_PACK_URL to the current thunderid pack

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,7 +16,7 @@ When triggering the workflow, you can configure the following parameters:
 
 | Parameter | Description | Default Value | Required |
 |-----------|-------------|--------------|----------|
-| `THUNDER_PACK_URL` | URL to download the Thunder pack | `https://github.com/asgardeo/thunder/releases/download/v0.7.0/thunder-v0.7.0-linux-x64.zip` | Yes |
+| `THUNDER_PACK_URL` | URL to download the Thunder pack | `https://github.com/thunder-id/thunderid/releases/download/v0.47.0/thunderid-0.47.0-linux-x64.zip` | Yes |
 | `DEPLOYMENT` | Deployment type | `single-node` | Yes |
 | `CPU_CORES` | Number of CPU cores for the VM | `4` (options: 2, 4, 8) | Yes |
 | `ADDITIONAL_PARAMS_TO_RUN_PERFORMANCE_SCRIPT` | Additional parameters for the performance script | `-d 15 -w 5 -x false -y JWT` | Yes |

--- a/.github/workflows/vm-perf-trigger.yml
+++ b/.github/workflows/vm-perf-trigger.yml
@@ -17,7 +17,7 @@ on:
       THUNDER_PACK_URL:
         description: 'URL to download Thunder pack'
         required: true
-        default: 'https://github.com/asgardeo/thunder/releases/download/v0.7.0/thunder-v0.7.0-linux-x64.zip'
+        default: 'https://github.com/thunder-id/thunderid/releases/download/v0.47.0/thunderid-0.47.0-linux-x64.zip'
         type: string
       DEPLOYMENT:
         description: 'Deployment type'

--- a/.github/workflows/vm-perf-workflow.yml
+++ b/.github/workflows/vm-perf-workflow.yml
@@ -11,7 +11,7 @@ on:
       THUNDER_PACK_URL:
         description: 'URL to download Thunder pack'
         required: true
-        default: 'https://github.com/asgardeo/thunder/releases/download/v0.7.0/thunder-v0.7.0-linux-x64.zip'
+        default: 'https://github.com/thunder-id/thunderid/releases/download/v0.47.0/thunderid-0.47.0-linux-x64.zip'
         type: string
       DEPLOYMENT:
         description: 'Deployment type'


### PR DESCRIPTION
## Purpose

The `THUNDER_PACK_URL` default in the workflow UI pointed to `asgardeo/thunder` **v0.7.0** — a different, older product. To run against a current thunderid build, users had to manually replace the URL, and leaving the stale default in place caused failed runs (the pack extracts to a different directory, so the Thunder/DB setup breaks).

This updates the default to the current `thunder-id/thunderid` pack so users can just accept the default. It also aligns with the existing `Publish test results to GitHub` step, which already gates on `https://github.com/thunder-id/thunderid/releases/download/` URLs.

## Changes

Updated the `THUNDER_PACK_URL` default in:
- `.github/workflows/vm-perf-workflow.yml`
- `.github/workflows/vm-perf-trigger.yml`
- `.github/workflows/README.md`

to `https://github.com/thunder-id/thunderid/releases/download/v0.47.0/thunderid-0.47.0-linux-x64.zip`.

## Note

This is a pinned version and will need bumping as new thunderid releases ship (same as before — the previous default had simply drifted).