### PR TITLE
Avoid sending an empty Authorization header during admin login

### DIFF
--- a/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
+++ b/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
@@ -87,7 +87,7 @@
         <collectionProp name="HeaderManager.headers">
           <elementProp name="Authorization" elementType="Header">
             <stringProp name="Header.name">Authorization</stringProp>
-            <stringProp name="Header.value">Bearer ${__P(adminAccessToken,)}</stringProp>
+            <stringProp name="Header.value">${__P(adminAuthHeader,)}</stringProp>
           </elementProp>
         </collectionProp>
       </HeaderManager>
@@ -485,7 +485,7 @@ vars.put('code_challenge', challenge)</stringProp>
             <stringProp name="parameters"></stringProp>
             <stringProp name="script">def token = vars.get('access_token')
 if (token != null &amp;&amp; token.trim().length() &gt; 0) {
-    props.put('adminAccessToken', token)
+    props.put('adminAuthHeader', 'Bearer ' + token)
 } else {
     log.error('Admin access token was empty; seeding will fail.')
     prev.setSuccessful(false)

--- a/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Users.jmx
+++ b/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Users.jmx
@@ -73,7 +73,7 @@
         <collectionProp name="HeaderManager.headers">
           <elementProp name="Authorization" elementType="Header">
             <stringProp name="Header.name">Authorization</stringProp>
-            <stringProp name="Header.value">Bearer ${__P(adminAccessToken,)}</stringProp>
+            <stringProp name="Header.value">${__P(adminAuthHeader,)}</stringProp>
           </elementProp>
         </collectionProp>
       </HeaderManager>
@@ -471,7 +471,7 @@ vars.put('code_challenge', challenge)</stringProp>
             <stringProp name="parameters"></stringProp>
             <stringProp name="script">def token = vars.get('access_token')
 if (token != null &amp;&amp; token.trim().length() &gt; 0) {
-    props.put('adminAccessToken', token)
+    props.put('adminAuthHeader', 'Bearer ' + token)
 } else {
     log.error('Admin access token was empty; seeding will fail.')
     prev.setSuccessful(false)


### PR DESCRIPTION
Follow-up fix to #63 (which merged before this correction was made).

## Problem

The admin-login step in the seeding plans failed at the token request (`/oauth2/token`), so seeding aborted (~20% error in the login group). Root cause: the plan-level `Authorization: Bearer ${__P(adminAccessToken,)}` header resolves to `Bearer ` (empty) while the login group is *obtaining* the token. Thunder's client-auth treats any non-empty `Authorization` header as `client_secret_basic` and then rejects it because it isn't `Basic …`, so the token request gets an invalid-client error. (The other login steps hit public endpoints and passed.)

## Fix

Switch the plan-level header value to `${__P(adminAuthHeader,)}` (empty by default) and have the login group set `adminAuthHeader = "Bearer <token>"` only after it obtains the token. During login the header is empty, so Thunder sees no `Authorization` header (`hasAuthHeader = false`) and the token request behaves like a normal public-client + PKCE call; during seeding the header carries the real bearer token.

Two-line change per plan (`TestData_Thunder_Add_Applications.jmx`, `TestData_Thunder_Add_Users.jmx`). The same fix is already on PR #62 (→ main).