### PR TITLE
Fix AWS perf tests for Thunder v0.48.0

### DIFF
--- a/perf-scripts/common/deployment/setup/resources/postgres/create_database.sql
+++ b/perf-scripts/common/deployment/setup/resources/postgres/create_database.sql
@@ -17,6 +17,7 @@
 create database "configdb";
 create database "runtimedb";
 create database "userdb";
+create database "operationdb";
 
 \c configdb
 \i /home/ubuntu/thunder/dbscripts/configdb/postgres.sql
@@ -24,4 +25,6 @@ create database "userdb";
 \i /home/ubuntu/thunder/dbscripts/runtimedb/postgres.sql
 \c userdb
 \i /home/ubuntu/thunder/dbscripts/userdb/postgres.sql
+\c operationdb
+\i /home/ubuntu/thunder/dbscripts/operationdb/postgres.sql
 

--- a/perf-scripts/common/jmeter/authenticate/Authenticate_With_Credentials.jmx
+++ b/perf-scripts/common/jmeter/authenticate/Authenticate_With_Credentials.jmx
@@ -78,6 +78,12 @@
             <stringProp name="Argument.value">${__P(noOfNodes,1)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="directAuthSecret" elementType="Argument">
+            <stringProp name="Argument.name">directAuthSecret</stringProp>
+            <stringProp name="Argument.value">${__P(directAuthSecret,)}</stringProp>
+            <stringProp name="Argument.desc">Gates the Direct API (/auth/**) since Thunder v0.48.0.</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -137,6 +143,10 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             <elementProp name="" elementType="Header">
               <stringProp name="Header.name">X-Server-Select</stringProp>
               <stringProp name="Header.value">${serverNode}</stringProp>
+            </elementProp>
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Direct-Auth-Secret</stringProp>
+              <stringProp name="Header.value">${directAuthSecret}</stringProp>
             </elementProp>
           </collectionProp>
         </HeaderManager>

--- a/perf-scripts/common/jmeter/perf-test-thunder.sh
+++ b/perf-scripts/common/jmeter/perf-test-thunder.sh
@@ -91,6 +91,12 @@ use_delay=true
 jwt_token_client_secret=""
 jwt_token_user_password=""
 
+# Gates the Direct API (/auth/**) since Thunder v0.48.0; sent as the Direct-Auth-Secret
+# header. Must match server.security.direct_auth_secret in the deployment.yaml under
+# perf-scripts/<deployment>/setup/resources/.
+default_direct_auth_secret="asgthunder-perf-direct-auth-secret"
+direct_auth_secret=$default_direct_auth_secret
+
 # Token Type
 token_issuer="Opaque"
 
@@ -120,7 +126,7 @@ function usage() {
     echo "   [-g <no_of_nodes>] [-f <deployment>] [-n <no_of_tenants>]"
     echo "   [-s <sp_count>] [-q <idp_count>] [-u <user_count>]"
     echo "   [-k <jwt_token_client_secret>] [-o <jwt_token_user_password>]"
-    echo "   [-x <enable_burst>] [-y <token_issuer>]"
+    echo "   [-x <enable_burst>] [-y <token_issuer>] [-a <direct_auth_secret>]"
     echo "   [-t] [-p <is_port>] [-b <db_type>] [-z <use_delay>] [-h]"
     echo ""
     echo "-c: Concurrency levels to test. You can give multiple options to specify multiple levels. Default \"$default_concurrent_users\"."
@@ -140,6 +146,7 @@ function usage() {
     echo "-o: JWT token user password."
     echo "-x: Enable burst traffic."
     echo "-y: Token issuer type. Use Opaque (default) or JWT."
+    echo "-a: Direct Auth Secret gating the Direct API (/auth/**). Default \"$default_direct_auth_secret\"."
     echo "-t: Estimate time without executing tests."
     echo "-p: Thunder Port. Default $default_is_port."
     echo "-b: Database type."
@@ -148,7 +155,7 @@ function usage() {
     echo ""
 }
 
-while getopts "c:d:w:r:j:i:e:g:f:n:s:q:u:tp:k:x:o:y:b:z:h" opts; do
+while getopts "c:d:w:r:j:i:e:g:f:n:s:q:u:tp:k:x:o:y:b:z:a:h" opts; do
     case $opts in
     c)
         concurrent_users+=("${OPTARG}")
@@ -212,6 +219,9 @@ while getopts "c:d:w:r:j:i:e:g:f:n:s:q:u:tp:k:x:o:y:b:z:h" opts; do
         ;;
     y)
         token_issuer=${OPTARG}
+        ;;
+    a)
+        direct_auth_secret=${OPTARG}
         ;;
     h)
         usage
@@ -602,7 +612,7 @@ function test_scenarios() {
             mkdir -p "$report_location"
 
             time=$(expr "$test_duration" \* 60)
-            declare -a jmeter_params=("concurrency=$users" "time=$time" "host=$lb_host" "port=$is_port" "noOfNodes=$noOfNodes" "noOfBurst=$burstTraffic" "deployment=$deployment" "userCount=$userCount" "useDelay=$use_delay")
+            declare -a jmeter_params=("concurrency=$users" "time=$time" "host=$lb_host" "port=$is_port" "noOfNodes=$noOfNodes" "noOfBurst=$burstTraffic" "deployment=$deployment" "userCount=$userCount" "useDelay=$use_delay" "directAuthSecret=$direct_auth_secret")
 
             local tenantMode=${scenario[tenantMode]}
             if [ "$tenantMode" = true ]; then

--- a/perf-scripts/single-node/setup/resources/deployment.yaml
+++ b/perf-scripts/single-node/setup/resources/deployment.yaml
@@ -67,6 +67,18 @@ database:
           max_open_conns: 20
           max_idle_conns: 20
           conn_max_lifetime: 300
+    operation:
+        type: "postgres"
+        postgres:
+          hostname: "{db_hostname}"
+          port: 5432
+          name: "operationdb"
+          username: "asgthunder"
+          password: "asgthunder"
+          sslmode: "disable"
+          max_open_conns: 20
+          max_idle_conns: 20
+          conn_max_lifetime: 300
 
 cache:
   disabled: false

--- a/perf-scripts/single-node/setup/resources/deployment.yaml
+++ b/perf-scripts/single-node/setup/resources/deployment.yaml
@@ -17,6 +17,12 @@
 server:
   hostname: "thunder.wso2.com"
   port: 8090
+  security:
+    # Gates the Direct API (/auth/**) since Thunder v0.48.0. Pinned here so the JMeter
+    # client can send the matching Direct-Auth-Secret header; setup.sh honours an existing
+    # value instead of generating a random one. Must match direct_auth_secret in
+    # perf-scripts/common/jmeter/perf-test-thunder.sh.
+    direct_auth_secret: "asgthunder-perf-direct-auth-secret"
 
 gate_client:
   hostname: "thunder.wso2.com"


### PR DESCRIPTION
### Purpose

Fixes the AWS perf test failing against Thunder v0.48.0 with `100.00% errors` during test data seeding:

```
ERROR: Test data seeding failed for TestData_Thunder_Add_Applications.jmx: 100.00% errors (threshold 1%).
       This typically means the management APIs rejected the requests (401/403).
```

Nothing was rejected — the Thunder server never started.

### Root cause

v0.48.0 requires a fourth database, `operation`, which the perf setup never configured or created. Our `deployment.yaml` defines only `config`, `runtime`, and `user`. Thunder's own bundled `deployment.yaml` has always defined `operation`, so v0.47.0 tolerated the omission; v0.48.0 does not:

```
level=ERROR msg="Failed to initialize SSO session service"
  error="failed to get runtime DB transactioner for the SSO session service:
         failed to get operation database client: database type is not configured"
❌ Bootstrap failed.
```

`operationdb` holds the tables behind two v0.48.0 changes — `SSO_SESSION*` (flow-centric browser SSO) and `REVOKED_TOKEN` (token revocation now defaults to `source: "db"`). The SSO session service initialises unconditionally at startup, so the missing config is fatal.

With the server dead, nginx had no upstream, JMeter's first `/oauth2/authorize` request failed in 469ms with a non-302, and `stoptest` halted the run — hence exactly 1 sample at 100% errors.

### Changes

- `perf-scripts/single-node/setup/resources/deployment.yaml` — add the `operation` Postgres stanza pointing at `operationdb`.
- `perf-scripts/common/deployment/setup/resources/postgres/create_database.sql` — create `operationdb` and load `dbscripts/operationdb/postgres.sql`.

### Verification

Ran both packs side by side under this repo's `deployment.yaml` (parsed from the actual file; Postgres swapped for SQLite locally):

| | v0.47.0 | v0.48.0 |
|---|---|---|
| before (no `operation`) | readiness 200 | server exits, unreachable |
| after (this PR) | readiness 200 | readiness 200 |

With the fix, `setup.sh` exits 0 with no errors and the `/oauth2/authorize` request that failed in CI returns `302`, satisfying the JMX's `HTTP/1.1 302` assertion with `authId` and `executionId` both extractable.

Note: the SQLite swap exercises the config shape and the startup dependency, which is what broke. The `\i` of `operationdb/postgres.sql` against RDS is only exercised by CI — a successful run should now log four `CREATE DATABASE` lines instead of three.

---

## Second fix: Direct API now requires the `Direct-Auth-Secret` header

With seeding fixed, the `Authenticate_With_Credentials` scenario then failed at **100% errors** (191,993 samples, ~40ms each):

```
summary = 191993 in 00:03:00 = 1065.8/s Avg: 40 Min: 1 Max: 682 Err: 191993 (100.00%)
```

That JMX posts to `/auth/credentials/authenticate`, a Direct API endpoint. v0.48.0 gates `/auth/**` behind `server.security.direct_auth_secret` and requires callers to send it as a `Direct-Auth-Secret` header — every request was rejected at the security middleware, which is why they were uniformly fast.

Compounding it: `setup.sh` **generates a random secret per run** when none is configured, so the JMeter client could never know the value. It does, however, honour an existing non-empty value — so the secret is now pinned in `deployment.yaml` and passed through to JMeter.

### Changes

- `perf-scripts/single-node/setup/resources/deployment.yaml` — pin `server.security.direct_auth_secret`.
- `perf-scripts/common/jmeter/perf-test-thunder.sh` — new `-a <direct_auth_secret>` option (default matches the config), passed to scenarios as `-JdirectAuthSecret`.
- `perf-scripts/common/jmeter/authenticate/Authenticate_With_Credentials.jmx` — add the `directAuthSecret` property and send the `Direct-Auth-Secret` header.

### Verification

Against v0.48.0 with this repo's `deployment.yaml`, using JMeter 5.6.3 (the version CI uses):

| Run | Result |
|---|---|
| JMX **without** `-JdirectAuthSecret` (control) | **401** `AUTH-4010` — reproduces the CI failure exactly |
| JMX **with** `-JdirectAuthSecret` | **404** `AUTHN-1008` — security gate passed; 404 only because no users were seeded locally |
| `curl` with header + real user | **200 OK**, returning the `id` the JMX asserts on |

Also confirmed `setup.sh` honours the pinned secret rather than generating one.

### Scope

Only `Authenticate_With_Credentials.jmx` uses the Direct API. No JMX sends `flowSecret` in a request body, so the related v0.48.0 change moving `flowSecret` to a `Flow-Secret` header does not affect these tests.

The secret is a fixed, non-sensitive value for an ephemeral perf environment, consistent with the existing hardcoded `asgthunder` database credentials. It is duplicated in two files; both carry comments pointing at each other.

---

### Scope / follow-ups

Not addressed here:

- **Azure (AKS + Helm) is affected the same way** and is blocked upstream: the v0.48.0 Helm chart has no `configuration.database.operation` key, and `--set` on it is silently discarded. Tracked in thunder-id/thunderid#4013. Once the chart lands the key, `terraform/deployment/main.tf`, `devops-pipelines/variables.yaml`, `templates/setup-db-schema.yaml`, and `templates/install-thunder.yaml` all need updating.
- **`update-thunder-conf.sh` ignores `setup.sh`'s exit code** and uses fixed `sleep 60`/`sleep 30` instead of polling `/health/readiness`. This is why a hard startup failure surfaced 90 seconds later as a misleading JMeter error; the same class of failure will hide again.
- **The seeding JTL is written outside `results/`** and never collected — it would have identified this immediately.
- **`templates/summary.md:55`** crashes with `UndefinedError: list object has no element 0` when no scenarios run, masking the real failure.
