### PR TITLE
Fix AWS perf tests for Thunder v0.48.0

### DIFF
--- a/perf-scripts/common/deployment/setup/resources/postgres/create_database.sql
+++ b/perf-scripts/common/deployment/setup/resources/postgres/create_database.sql
@@ -17,6 +17,7 @@
 create database "configdb";
 create database "runtimedb";
 create database "userdb";
+create database "operationdb";
 
 \c configdb
 \i /home/ubuntu/thunder/dbscripts/configdb/postgres.sql
@@ -24,4 +25,6 @@ create database "userdb";
 \i /home/ubuntu/thunder/dbscripts/runtimedb/postgres.sql
 \c userdb
 \i /home/ubuntu/thunder/dbscripts/userdb/postgres.sql
+\c operationdb
+\i /home/ubuntu/thunder/dbscripts/operationdb/postgres.sql
 

--- a/perf-scripts/common/jmeter/authenticate/Authenticate_With_Credentials.jmx
+++ b/perf-scripts/common/jmeter/authenticate/Authenticate_With_Credentials.jmx
@@ -78,6 +78,12 @@
             <stringProp name="Argument.value">${__P(noOfNodes,1)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="directAuthSecret" elementType="Argument">
+            <stringProp name="Argument.name">directAuthSecret</stringProp>
+            <stringProp name="Argument.value">${__P(directAuthSecret,)}</stringProp>
+            <stringProp name="Argument.desc">Gates the Direct API (/auth/**) since Thunder v0.48.0.</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -137,6 +143,10 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
             <elementProp name="" elementType="Header">
               <stringProp name="Header.name">X-Server-Select</stringProp>
               <stringProp name="Header.value">${serverNode}</stringProp>
+            </elementProp>
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Direct-Auth-Secret</stringProp>
+              <stringProp name="Header.value">${directAuthSecret}</stringProp>
             </elementProp>
           </collectionProp>
         </HeaderManager>

--- a/perf-scripts/common/jmeter/perf-test-thunder.sh
+++ b/perf-scripts/common/jmeter/perf-test-thunder.sh
@@ -91,6 +91,12 @@ use_delay=true
 jwt_token_client_secret=""
 jwt_token_user_password=""
 
+# Gates the Direct API (/auth/**) since Thunder v0.48.0; sent as the Direct-Auth-Secret
+# header. Must match server.security.direct_auth_secret in the deployment.yaml under
+# perf-scripts/<deployment>/setup/resources/.
+default_direct_auth_secret="asgthunder-perf-direct-auth-secret"
+direct_auth_secret=$default_direct_auth_secret
+
 # Token Type
 token_issuer="Opaque"
 
@@ -120,7 +126,7 @@ function usage() {
     echo "   [-g <no_of_nodes>] [-f <deployment>] [-n <no_of_tenants>]"
     echo "   [-s <sp_count>] [-q <idp_count>] [-u <user_count>]"
     echo "   [-k <jwt_token_client_secret>] [-o <jwt_token_user_password>]"
-    echo "   [-x <enable_burst>] [-y <token_issuer>]"
+    echo "   [-x <enable_burst>] [-y <token_issuer>] [-a <direct_auth_secret>]"
     echo "   [-t] [-p <is_port>] [-b <db_type>] [-z <use_delay>] [-h]"
     echo ""
     echo "-c: Concurrency levels to test. You can give multiple options to specify multiple levels. Default \"$default_concurrent_users\"."
@@ -140,6 +146,7 @@ function usage() {
     echo "-o: JWT token user password."
     echo "-x: Enable burst traffic."
     echo "-y: Token issuer type. Use Opaque (default) or JWT."
+    echo "-a: Direct Auth Secret gating the Direct API (/auth/**). Default \"$default_direct_auth_secret\"."
     echo "-t: Estimate time without executing tests."
     echo "-p: Thunder Port. Default $default_is_port."
     echo "-b: Database type."
@@ -148,7 +155,7 @@ function usage() {
     echo ""
 }
 
-while getopts "c:d:w:r:j:i:e:g:f:n:s:q:u:tp:k:x:o:y:b:z:h" opts; do
+while getopts "c:d:w:r:j:i:e:g:f:n:s:q:u:tp:k:x:o:y:b:z:a:h" opts; do
     case $opts in
     c)
         concurrent_users+=("${OPTARG}")
@@ -212,6 +219,9 @@ while getopts "c:d:w:r:j:i:e:g:f:n:s:q:u:tp:k:x:o:y:b:z:h" opts; do
         ;;
     y)
         token_issuer=${OPTARG}
+        ;;
+    a)
+        direct_auth_secret=${OPTARG}
         ;;
     h)
         usage
@@ -602,7 +612,7 @@ function test_scenarios() {
             mkdir -p "$report_location"
 
             time=$(expr "$test_duration" \* 60)
-            declare -a jmeter_params=("concurrency=$users" "time=$time" "host=$lb_host" "port=$is_port" "noOfNodes=$noOfNodes" "noOfBurst=$burstTraffic" "deployment=$deployment" "userCount=$userCount" "useDelay=$use_delay")
+            declare -a jmeter_params=("concurrency=$users" "time=$time" "host=$lb_host" "port=$is_port" "noOfNodes=$noOfNodes" "noOfBurst=$burstTraffic" "deployment=$deployment" "userCount=$userCount" "useDelay=$use_delay" "directAuthSecret=$direct_auth_secret")
 
             local tenantMode=${scenario[tenantMode]}
             if [ "$tenantMode" = true ]; then

--- a/perf-scripts/single-node/setup/resources/deployment.yaml
+++ b/perf-scripts/single-node/setup/resources/deployment.yaml
@@ -67,6 +67,18 @@ database:
           max_open_conns: 20
           max_idle_conns: 20
           conn_max_lifetime: 300
+    operation:
+        type: "postgres"
+        postgres:
+          hostname: "{db_hostname}"
+          port: 5432
+          name: "operationdb"
+          username: "asgthunder"
+          password: "asgthunder"
+          sslmode: "disable"
+          max_open_conns: 20
+          max_idle_conns: 20
+          conn_max_lifetime: 300
 
 cache:
   disabled: false

--- a/perf-scripts/single-node/setup/resources/deployment.yaml
+++ b/perf-scripts/single-node/setup/resources/deployment.yaml
@@ -17,6 +17,12 @@
 server:
   hostname: "thunder.wso2.com"
   port: 8090
+  security:
+    # Gates the Direct API (/auth/**) since Thunder v0.48.0. Pinned here so the JMeter
+    # client can send the matching Direct-Auth-Secret header; setup.sh honours an existing
+    # value instead of generating a random one. Must match direct_auth_secret in
+    # perf-scripts/common/jmeter/perf-test-thunder.sh.
+    direct_auth_secret: "asgthunder-perf-direct-auth-secret"
 
 gate_client:
   hostname: "thunder.wso2.com"


### PR DESCRIPTION
## Purpose

Thunder v0.48.0 broke the AWS perf suite in two ways, both showing up as `100.00% errors`.

[thunder-id/thunderid#3779](https://github.com/thunder-id/thunderid/pull/3779) added an `operation` database and made the SSO session service initialise at startup. Our `deployment.yaml` only defines `config`, `runtime` and `user`, so v0.48.0 exits with `failed to get operation database client: database type is not configured` and never binds a port. Seeding failed because Thunder was down, so the harness reporting "management APIs rejected the requests (401/403)" is misleading. ([run #29312371882](https://github.com/asgardeo/thunder-performance/actions/runs/29312371882))

[thunder-id/thunderid#3762](https://github.com/thunder-id/thunderid/pull/3762) gates `/auth/**` behind `server.security.direct_auth_secret`, so `Authenticate_With_Credentials.jmx` was rejected at the security middleware on every request (191,993 samples, ~40ms each). `setup.sh` generates a random secret per run when none is configured, but honours a pinned one. ([run #29396473094](https://github.com/asgardeo/thunder-performance/actions/runs/29396473094))

## Changes

- `create_database.sql`: create `operationdb` and load its schema.
- `deployment.yaml`: add the `operation` stanza, and pin `server.security.direct_auth_secret`.
- `perf-test-thunder.sh`: new `-a` option, passed to the scenarios as `-JdirectAuthSecret`.
- `Authenticate_With_Credentials.jmx`: send the `Direct-Auth-Secret` header.
