### PR TITLE
Update db hostname in k8s pipeline

### DIFF
--- a/kubernetes/azure/devops-pipelines/templates/populate-test-data.yaml
+++ b/kubernetes/azure/devops-pipelines/templates/populate-test-data.yaml
@@ -50,7 +50,7 @@ steps:
       GITHUB_USERNAME: $(gitUsername)
       BUILD_TYPE: $(Build.Reason)
       BUILD_PATH: $(Build.ArtifactStagingDirectory)
-      DATABASE_HOST_NAME: $(DATABASE_HOSTNAME)
+      DATABASE_HOST_NAME: $(CONFIG_DB_HOSTNAME)
       THUNDER_HOST_NAME: $(THUNDER_HOSTNAME)
       POPULATE_TEST_DATA: "true"
       RUN_MODE: "NONE"


### PR DESCRIPTION
## Purpose

This pull request updates the database host environment variable used in the `populate-test-data.yaml` pipeline template to ensure it references the correct configuration.

Configuration update:

* Changed the environment variable `DATABASE_HOST_NAME` to use `$(CONFIG_DB_HOSTNAME)` instead of `$(DATABASE_HOSTNAME)` in `kubernetes/azure/devops-pipelines/templates/populate-test-data.yaml` to align with the correct configuration variable.