### PR TITLE
Update Thunder helm install for compatibility with Thunder v0.47.0

### DIFF
--- a/kubernetes/azure/devops-pipelines/deploy-thunder.yaml
+++ b/kubernetes/azure/devops-pipelines/deploy-thunder.yaml
@@ -140,7 +140,6 @@ jobs:
           THUNDER_IMAGE_REGISTRY: ${{ parameters.THUNDER_IMAGE_REGISTRY }}
           THUNDER_IMAGE_REPOSITORY: ${{ parameters.THUNDER_IMAGE_REPOSITORY }}
           THUNDER_IMAGE_TAG: ${{ parameters.THUNDER_IMAGE_TAG }}
-          SKIP_SECURITY: 'true'
 
   - job: add_hosts_entry_to_vm
     displayName: Add Hosts Entry to VM

--- a/kubernetes/azure/devops-pipelines/templates/install-thunder.yaml
+++ b/kubernetes/azure/devops-pipelines/templates/install-thunder.yaml
@@ -32,9 +32,6 @@ parameters:
   - name: THUNDER_IMAGE_TAG
     type: string
     default: '0.7.0'
-  - name: SKIP_SECURITY
-    type: string
-    default: 'false'
   - name: RUN_SETUP_SCRIPT
     type: boolean
     default: true
@@ -72,30 +69,43 @@ steps:
           --set configuration.database.config.postgres.port=$(CONFIG_DB_PORT) \
           --set configuration.database.config.postgres.username=$(POSTGRES-ADMIN-USERNAME) \
           --set configuration.database.config.postgres.password=$(POSTGRES-ADMIN-PASSWORD) \
+          --set configuration.database.config.postgres.sslmode=$(DB_SSL_MODE) \
           --set configuration.database.config.postgres.max_open_conns=$(DB_MAX_OPEN_CONNS) \
           --set configuration.database.config.postgres.max_idle_conns=$(DB_MAX_IDLE_CONNS) \
           --set configuration.database.config.postgres.conn_max_lifetime=$(DB_CONN_MAX_LIFETIME) \
+          --set configuration.database.config.postgres.max_retries=$(DB_MAX_RETRIES) \
+          --set configuration.database.config.postgres.min_retry_backoff_ms=$(DB_MIN_RETRY_BACKOFF_MS) \
+          --set configuration.database.config.postgres.max_retry_backoff_ms=$(DB_MAX_RETRY_BACKOFF_MS) \
           --set configuration.database.runtime.type=$(RUNTIME_DB_TYPE) \
           --set configuration.database.runtime.postgres.name=$(RUNTIME_DB_NAME) \
           --set configuration.database.runtime.postgres.hostname=$(RUNTIME_DB_HOST) \
           --set configuration.database.runtime.postgres.port=$(RUNTIME_DB_PORT) \
           --set configuration.database.runtime.postgres.username=$(POSTGRES-ADMIN-USERNAME) \
           --set configuration.database.runtime.postgres.password=$(POSTGRES-ADMIN-PASSWORD) \
+          --set configuration.database.runtime.postgres.sslmode=$(DB_SSL_MODE) \
           --set configuration.database.runtime.postgres.max_open_conns=$(DB_MAX_OPEN_CONNS) \
           --set configuration.database.runtime.postgres.max_idle_conns=$(DB_MAX_IDLE_CONNS) \
           --set configuration.database.runtime.postgres.conn_max_lifetime=$(DB_CONN_MAX_LIFETIME) \
+          --set configuration.database.runtime.postgres.max_retries=$(DB_MAX_RETRIES) \
+          --set configuration.database.runtime.postgres.min_retry_backoff_ms=$(DB_MIN_RETRY_BACKOFF_MS) \
+          --set configuration.database.runtime.postgres.max_retry_backoff_ms=$(DB_MAX_RETRY_BACKOFF_MS) \
           --set configuration.database.user.type=$(USER_DB_TYPE) \
           --set configuration.database.user.postgres.name=$(USER_DB_NAME) \
           --set configuration.database.user.postgres.hostname=$(USER_DB_HOST) \
           --set configuration.database.user.postgres.port=$(USER_DB_PORT) \
           --set configuration.database.user.postgres.username=$(POSTGRES-ADMIN-USERNAME) \
           --set configuration.database.user.postgres.password=$(POSTGRES-ADMIN-PASSWORD) \
+          --set configuration.database.user.postgres.sslmode=$(DB_SSL_MODE) \
           --set configuration.database.user.postgres.max_open_conns=$(DB_MAX_OPEN_CONNS) \
           --set configuration.database.user.postgres.max_idle_conns=$(DB_MAX_IDLE_CONNS) \
           --set configuration.database.user.postgres.conn_max_lifetime=$(DB_CONN_MAX_LIFETIME) \
+          --set configuration.database.user.postgres.max_retries=$(DB_MAX_RETRIES) \
+          --set configuration.database.user.postgres.min_retry_backoff_ms=$(DB_MIN_RETRY_BACKOFF_MS) \
+          --set configuration.database.user.postgres.max_retry_backoff_ms=$(DB_MAX_RETRY_BACKOFF_MS) \
           --set configuration.consent.enabled=false \
           --set configuration.crypto.passwordHashing.algorithm=$(THUNDER_PASSWORD_HASHING_ALGORITHM) \
-          --set deployment.skipSecurity=${{ parameters.SKIP_SECURITY }} \
           --set setup.enabled=${{ parameters.RUN_SETUP_SCRIPT }} \
+          --set setup.admin.username=$(THUNDER_ADMIN_USERNAME) \
+          --set setup.admin.password=$(THUNDER_ADMIN_PASSWORD) \
           --set configuration.cache.disabled=false
         echo "Thunder Helm Chart installed successfully"

--- a/kubernetes/azure/devops-pipelines/templates/reinstall-thunder.yaml
+++ b/kubernetes/azure/devops-pipelines/templates/reinstall-thunder.yaml
@@ -32,9 +32,6 @@ parameters:
   - name: THUNDER_IMAGE_TAG
     type: string
     default: '0.7.0'
-  - name: SKIP_SECURITY
-    type: string
-    default: 'false'
   - name: RUN_SETUP_SCRIPT
     type: boolean
     default: false
@@ -71,5 +68,4 @@ steps:
       THUNDER_IMAGE_REGISTRY: ${{ parameters.THUNDER_IMAGE_REGISTRY }}
       THUNDER_IMAGE_REPOSITORY: ${{ parameters.THUNDER_IMAGE_REPOSITORY }}
       THUNDER_IMAGE_TAG: ${{ parameters.THUNDER_IMAGE_TAG }}
-      SKIP_SECURITY: ${{ parameters.SKIP_SECURITY }}
       RUN_SETUP_SCRIPT: ${{ parameters.RUN_SETUP_SCRIPT }}

--- a/kubernetes/azure/devops-pipelines/variables.yaml
+++ b/kubernetes/azure/devops-pipelines/variables.yaml
@@ -33,7 +33,6 @@ variables:
   TLS_SECRET_NAME: "thunder-tls"
   THUNDER_KUBERNETES_INGRESS: "thunder-perf-thunderid-ingress"
   THUNDER_HOSTNAME: "thunderid.local"
-  SKIP_SECURITY: 'true'
 
   # Thunder Deployment Configuration
   THUNDER_REPLICAS: '2'
@@ -44,6 +43,10 @@ variables:
 
   # Thunder Crypto Configuration
   THUNDER_PASSWORD_HASHING_ALGORITHM: 'SHA256'
+
+  # Thunder Setup (admin user seeded by the setup job)
+  THUNDER_ADMIN_USERNAME: 'admin'
+  THUNDER_ADMIN_PASSWORD: 'admin'
 
   # HPA and Cache Configuration
   THUNDER_HPA_ENABLED: 'true'
@@ -64,8 +67,15 @@ variables:
   USER_DB_NAME: 'userdb'
   USER_DB_HOST: $(USER_DB_HOSTNAME)
   USER_DB_PORT: '5432'
+  # SSL mode used when connecting to the Postgres servers (Azure Postgres enforces SSL).
+  DB_SSL_MODE: 'require'
 
   # Database Connection Pool Configuration
   DB_MAX_OPEN_CONNS: '10'
   DB_MAX_IDLE_CONNS: '10'
   DB_CONN_MAX_LIFETIME: '3600'
+
+  # Database Retry Configuration
+  DB_MAX_RETRIES: '3'
+  DB_MIN_RETRY_BACKOFF_MS: '50'
+  DB_MAX_RETRY_BACKOFF_MS: '2000'


### PR DESCRIPTION
## Purpose

Align the Thunder helm install steps with the `install/helm` chart shipped in Thunder v0.47.0.

## Changes

- Removed the dead `--set deployment.skipSecurity` flag (and its `SKIP_SECURITY` parameter plumbing across `install-thunder.yaml`, `reinstall-thunder.yaml`, and `deploy-thunder.yaml`). This key does not exist in the v0.47.0 chart, so Helm was silently ignoring it.
- Wired the new v0.47.0 Postgres keys for the `config`, `runtime`, and `user` databases: `sslmode`, `max_retries`, `min_retry_backoff_ms`, `max_retry_backoff_ms`.
- Wired `setup.admin.username` / `setup.admin.password`, defaulting to `admin`/`admin` to match the JMeter test defaults.
- Added the backing pipeline variables in `variables.yaml`: `DB_SSL_MODE`, `DB_MAX_RETRIES`, `DB_MIN_RETRY_BACKOFF_MS`, `DB_MAX_RETRY_BACKOFF_MS`, `THUNDER_ADMIN_USERNAME`, `THUNDER_ADMIN_PASSWORD`.

## Notes

- Every new `--set` key was verified against the v0.47.0 chart templates (`conf/deployment.yaml` for the DB keys, `templates/setup-job.yaml` for the admin keys), so none are dead flags.
- `DB_SSL_MODE` defaults to `require`, matching both the chart default and Azure Postgres Flexible Server SSL enforcement, so runtime behavior is unchanged. It is now explicit and tunable.