### PR TITLE
Update perf test harness for Thunder v0.47.0

### DIFF
--- a/kubernetes/azure/devops-pipelines/deploy-thunder.yaml
+++ b/kubernetes/azure/devops-pipelines/deploy-thunder.yaml
@@ -70,7 +70,7 @@ parameters:
   - name: THUNDER_IMAGE_TAG
     displayName: Thunder Image Tag
     type: string
-    default: "0.38.0"
+    default: "0.47.0"
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -140,7 +140,6 @@ jobs:
           THUNDER_IMAGE_REGISTRY: ${{ parameters.THUNDER_IMAGE_REGISTRY }}
           THUNDER_IMAGE_REPOSITORY: ${{ parameters.THUNDER_IMAGE_REPOSITORY }}
           THUNDER_IMAGE_TAG: ${{ parameters.THUNDER_IMAGE_TAG }}
-          SKIP_SECURITY: 'true'
 
   - job: add_hosts_entry_to_vm
     displayName: Add Hosts Entry to VM

--- a/kubernetes/azure/devops-pipelines/templates/install-thunder.yaml
+++ b/kubernetes/azure/devops-pipelines/templates/install-thunder.yaml
@@ -32,9 +32,6 @@ parameters:
   - name: THUNDER_IMAGE_TAG
     type: string
     default: '0.7.0'
-  - name: SKIP_SECURITY
-    type: string
-    default: 'false'
   - name: RUN_SETUP_SCRIPT
     type: boolean
     default: true
@@ -50,6 +47,46 @@ steps:
       workingDirectory: ${{ parameters.WORKING_DIRECTORY }}
       inlineScript: |
         set -e
+        SETUP_JOB=${{ parameters.RELEASE_NAME }}-thunderid-setup
+        SETUP_LOG=$(mktemp)
+        dump_thunder_diagnostics() {
+          echo "##[error]Thunder install did not become ready. Dumping diagnostics:"
+          kubectl get pods -n ${{ parameters.NAMESPACE }} -o wide || true
+          kubectl get events -n ${{ parameters.NAMESPACE }} --sort-by=.lastTimestamp | tail -n 30 || true
+          THUNDER_POD=$(kubectl get pods -n ${{ parameters.NAMESPACE }} -l app.kubernetes.io/instance=${{ parameters.RELEASE_NAME }} -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+          if [ -n "$THUNDER_POD" ]; then
+            kubectl describe pod "$THUNDER_POD" -n ${{ parameters.NAMESPACE }} || true
+            kubectl logs "$THUNDER_POD" -n ${{ parameters.NAMESPACE }} --all-containers --tail=200 || true
+            kubectl logs "$THUNDER_POD" -n ${{ parameters.NAMESPACE }} --all-containers --previous --tail=200 || true
+          fi
+          echo "--- Setup/bootstrap job (seeds default resources incl. the Console app) ---"
+          kubectl describe job "$SETUP_JOB" -n ${{ parameters.NAMESPACE }} || true
+          # The setup pod is deleted the instant the job hits BackoffLimitExceeded, so a
+          # post-hoc "kubectl logs" loses the race. Prefer the log captured live below.
+          echo "--- Setup/bootstrap job logs (captured live) ---"
+          cat "$SETUP_LOG" 2>/dev/null || true
+          echo "--- Setup/bootstrap job logs (post-hoc, may be empty if pod already deleted) ---"
+          kubectl logs job/"$SETUP_JOB" -n ${{ parameters.NAMESPACE }} --all-containers --tail=200 || true
+          kubectl logs -n ${{ parameters.NAMESPACE }} -l job-name="$SETUP_JOB" --all-containers --tail=200 || true
+          kubectl logs -n ${{ parameters.NAMESPACE }} -l job-name="$SETUP_JOB" --all-containers --previous --tail=200 || true
+        }
+        trap dump_thunder_diagnostics ERR
+        # Background collector: stream the setup pod's logs to a file while the pre-install
+        # hook runs, so the crash output survives the job controller deleting the failed pod.
+        (
+          for _ in $(seq 1 90); do
+            POD=$(kubectl get pods -n ${{ parameters.NAMESPACE }} -l job-name="$SETUP_JOB" \
+              -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+            if [ -n "$POD" ]; then
+              for p in $POD; do
+                kubectl logs -f "$p" -n ${{ parameters.NAMESPACE }} --all-containers \
+                  --pod-running-timeout=30s >> "$SETUP_LOG" 2>/dev/null || true
+              done
+            fi
+            sleep 2
+          done
+        ) &
+        SETUP_LOG_COLLECTOR_PID=$!
         echo "Installing Thunder Helm Chart"
         helm upgrade --install ${{ parameters.RELEASE_NAME }} . \
           --namespace ${{ parameters.NAMESPACE }} \
@@ -72,30 +109,56 @@ steps:
           --set configuration.database.config.postgres.port=$(CONFIG_DB_PORT) \
           --set configuration.database.config.postgres.username=$(POSTGRES-ADMIN-USERNAME) \
           --set configuration.database.config.postgres.password=$(POSTGRES-ADMIN-PASSWORD) \
+          --set configuration.database.config.postgres.sslmode=$(DB_SSL_MODE) \
           --set configuration.database.config.postgres.max_open_conns=$(DB_MAX_OPEN_CONNS) \
           --set configuration.database.config.postgres.max_idle_conns=$(DB_MAX_IDLE_CONNS) \
           --set configuration.database.config.postgres.conn_max_lifetime=$(DB_CONN_MAX_LIFETIME) \
+          --set configuration.database.config.postgres.max_retries=$(DB_MAX_RETRIES) \
+          --set configuration.database.config.postgres.min_retry_backoff_ms=$(DB_MIN_RETRY_BACKOFF_MS) \
+          --set configuration.database.config.postgres.max_retry_backoff_ms=$(DB_MAX_RETRY_BACKOFF_MS) \
           --set configuration.database.runtime.type=$(RUNTIME_DB_TYPE) \
           --set configuration.database.runtime.postgres.name=$(RUNTIME_DB_NAME) \
           --set configuration.database.runtime.postgres.hostname=$(RUNTIME_DB_HOST) \
           --set configuration.database.runtime.postgres.port=$(RUNTIME_DB_PORT) \
           --set configuration.database.runtime.postgres.username=$(POSTGRES-ADMIN-USERNAME) \
           --set configuration.database.runtime.postgres.password=$(POSTGRES-ADMIN-PASSWORD) \
+          --set configuration.database.runtime.postgres.sslmode=$(DB_SSL_MODE) \
           --set configuration.database.runtime.postgres.max_open_conns=$(DB_MAX_OPEN_CONNS) \
           --set configuration.database.runtime.postgres.max_idle_conns=$(DB_MAX_IDLE_CONNS) \
           --set configuration.database.runtime.postgres.conn_max_lifetime=$(DB_CONN_MAX_LIFETIME) \
+          --set configuration.database.runtime.postgres.max_retries=$(DB_MAX_RETRIES) \
+          --set configuration.database.runtime.postgres.min_retry_backoff_ms=$(DB_MIN_RETRY_BACKOFF_MS) \
+          --set configuration.database.runtime.postgres.max_retry_backoff_ms=$(DB_MAX_RETRY_BACKOFF_MS) \
           --set configuration.database.user.type=$(USER_DB_TYPE) \
           --set configuration.database.user.postgres.name=$(USER_DB_NAME) \
           --set configuration.database.user.postgres.hostname=$(USER_DB_HOST) \
           --set configuration.database.user.postgres.port=$(USER_DB_PORT) \
           --set configuration.database.user.postgres.username=$(POSTGRES-ADMIN-USERNAME) \
           --set configuration.database.user.postgres.password=$(POSTGRES-ADMIN-PASSWORD) \
+          --set configuration.database.user.postgres.sslmode=$(DB_SSL_MODE) \
           --set configuration.database.user.postgres.max_open_conns=$(DB_MAX_OPEN_CONNS) \
           --set configuration.database.user.postgres.max_idle_conns=$(DB_MAX_IDLE_CONNS) \
           --set configuration.database.user.postgres.conn_max_lifetime=$(DB_CONN_MAX_LIFETIME) \
+          --set configuration.database.user.postgres.max_retries=$(DB_MAX_RETRIES) \
+          --set configuration.database.user.postgres.min_retry_backoff_ms=$(DB_MIN_RETRY_BACKOFF_MS) \
+          --set configuration.database.user.postgres.max_retry_backoff_ms=$(DB_MAX_RETRY_BACKOFF_MS) \
           --set configuration.consent.enabled=false \
           --set configuration.crypto.passwordHashing.algorithm=$(THUNDER_PASSWORD_HASHING_ALGORITHM) \
-          --set deployment.skipSecurity=${{ parameters.SKIP_SECURITY }} \
+          --set deployment.securityContext.readOnlyRootFilesystem=false \
           --set setup.enabled=${{ parameters.RUN_SETUP_SCRIPT }} \
-          --set configuration.cache.disabled=false
+          --set setup.admin.username=$(THUNDER_ADMIN_USERNAME) \
+          --set setup.admin.password=$(THUNDER_ADMIN_PASSWORD) \
+          --set configuration.cache.disabled=false \
+          --wait \
+          --timeout 5m
+        kill "$SETUP_LOG_COLLECTOR_PID" 2>/dev/null || true
         echo "Thunder Helm Chart installed successfully"
+        echo "=== Post-install Thunder status ==="
+        echo "--- Pods ---"
+        kubectl get pods -n ${{ parameters.NAMESPACE }} -o wide || true
+        echo "--- Services ---"
+        kubectl get svc -n ${{ parameters.NAMESPACE }} -o wide || true
+        echo "--- Endpoints (empty ENDPOINTS behind the Thunder service explains nginx 503) ---"
+        kubectl get endpoints -n ${{ parameters.NAMESPACE }} || true
+        echo "--- Ingress ---"
+        kubectl get ingress -n ${{ parameters.NAMESPACE }} -o wide || true

--- a/kubernetes/azure/devops-pipelines/templates/reinstall-thunder.yaml
+++ b/kubernetes/azure/devops-pipelines/templates/reinstall-thunder.yaml
@@ -32,9 +32,6 @@ parameters:
   - name: THUNDER_IMAGE_TAG
     type: string
     default: '0.7.0'
-  - name: SKIP_SECURITY
-    type: string
-    default: 'false'
   - name: RUN_SETUP_SCRIPT
     type: boolean
     default: false
@@ -71,5 +68,4 @@ steps:
       THUNDER_IMAGE_REGISTRY: ${{ parameters.THUNDER_IMAGE_REGISTRY }}
       THUNDER_IMAGE_REPOSITORY: ${{ parameters.THUNDER_IMAGE_REPOSITORY }}
       THUNDER_IMAGE_TAG: ${{ parameters.THUNDER_IMAGE_TAG }}
-      SKIP_SECURITY: ${{ parameters.SKIP_SECURITY }}
       RUN_SETUP_SCRIPT: ${{ parameters.RUN_SETUP_SCRIPT }}

--- a/kubernetes/azure/devops-pipelines/variables.yaml
+++ b/kubernetes/azure/devops-pipelines/variables.yaml
@@ -33,7 +33,6 @@ variables:
   TLS_SECRET_NAME: "thunder-tls"
   THUNDER_KUBERNETES_INGRESS: "thunder-perf-thunderid-ingress"
   THUNDER_HOSTNAME: "thunderid.local"
-  SKIP_SECURITY: 'true'
 
   # Thunder Deployment Configuration
   THUNDER_REPLICAS: '2'
@@ -44,6 +43,10 @@ variables:
 
   # Thunder Crypto Configuration
   THUNDER_PASSWORD_HASHING_ALGORITHM: 'SHA256'
+
+  # Thunder Setup (admin user seeded by the setup job)
+  THUNDER_ADMIN_USERNAME: 'admin'
+  THUNDER_ADMIN_PASSWORD: 'admin'
 
   # HPA and Cache Configuration
   THUNDER_HPA_ENABLED: 'true'
@@ -64,8 +67,19 @@ variables:
   USER_DB_NAME: 'userdb'
   USER_DB_HOST: $(USER_DB_HOSTNAME)
   USER_DB_PORT: '5432'
+  # SSL mode used when connecting to the Postgres servers (Azure Postgres enforces SSL).
+  DB_SSL_MODE: 'require'
+
+  # Consent (OpenFGC) is disabled for the perf environment (configuration.consent.enabled=false
+  # in install-thunder.yaml). The perf scenarios do not exercise consent, and the bundled consent
+  # server was the source of repeated bootstrap/deploy failures, so it is left out entirely.
 
   # Database Connection Pool Configuration
   DB_MAX_OPEN_CONNS: '10'
   DB_MAX_IDLE_CONNS: '10'
   DB_CONN_MAX_LIFETIME: '3600'
+
+  # Database Retry Configuration
+  DB_MAX_RETRIES: '3'
+  DB_MIN_RETRY_BACKOFF_MS: '50'
+  DB_MAX_RETRY_BACKOFF_MS: '2000'

--- a/perf-scripts/common/jmeter/perf-test-pre-provisioned.sh
+++ b/perf-scripts/common/jmeter/perf-test-pre-provisioned.sh
@@ -375,7 +375,7 @@ function run_test_data_scripts() {
 
     for script in "${scripts[@]}"; do
         script_file="$setup_dir/$script"
-        command="jmeter -Jhost=$lb_host -Jport=$thunder_port -n -t $script_file"
+        command="jmeter -Jhost=$lb_host -Jport=$thunder_port -JconsoleRedirectUri=https://$lb_host/console -n -t $script_file"
         echo "$command"
         echo ""
         $command

--- a/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
+++ b/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
@@ -133,6 +133,25 @@
         </elementProp>
       </ThreadGroup>
       <hashTree>
+        <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="DEBUG Log admin flow response" enabled="true">
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="cacheKey">true</stringProp>
+          <stringProp name="script">String label = prev.getSampleLabel();
+boolean ok = prev.isSuccessful();
+String rc = prev.getResponseCode();
+String rm = prev.getResponseMessage();
+String body = prev.getResponseDataAsString();
+if (body == null) { body = ""; }
+if (body.length() &gt; 4000) { body = body.substring(0, 4000) + " ...[truncated]"; }
+String headers = prev.getResponseHeaders();
+System.out.println("[SETUP-DEBUG] sampler=[" + label + "] success=" + ok + " responseCode=" + rc + " responseMessage=" + rm);
+System.out.println("[SETUP-DEBUG] response-headers: " + headers);
+System.out.println("[SETUP-DEBUG] response-body: " + body);
+log.warn("[SETUP-DEBUG] sampler=[" + label + "] success=" + ok + " responseCode=" + rc + " body=" + body);</stringProp>
+        </JSR223PostProcessor>
+        <hashTree/>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="1 Send request to authorize endpoint" enabled="true">
           <stringProp name="HTTPSampler.domain">${thunder_host}</stringProp>
           <stringProp name="HTTPSampler.port">${thunder_port}</stringProp>

--- a/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Users.jmx
+++ b/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Users.jmx
@@ -119,6 +119,25 @@
         </elementProp>
       </ThreadGroup>
       <hashTree>
+        <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="DEBUG Log admin flow response" enabled="true">
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="cacheKey">true</stringProp>
+          <stringProp name="script">String label = prev.getSampleLabel();
+boolean ok = prev.isSuccessful();
+String rc = prev.getResponseCode();
+String rm = prev.getResponseMessage();
+String body = prev.getResponseDataAsString();
+if (body == null) { body = ""; }
+if (body.length() &gt; 4000) { body = body.substring(0, 4000) + " ...[truncated]"; }
+String headers = prev.getResponseHeaders();
+System.out.println("[SETUP-DEBUG] sampler=[" + label + "] success=" + ok + " responseCode=" + rc + " responseMessage=" + rm);
+System.out.println("[SETUP-DEBUG] response-headers: " + headers);
+System.out.println("[SETUP-DEBUG] response-body: " + body);
+log.warn("[SETUP-DEBUG] sampler=[" + label + "] success=" + ok + " responseCode=" + rc + " body=" + body);</stringProp>
+        </JSR223PostProcessor>
+        <hashTree/>
         <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="1 Send request to authorize endpoint" enabled="true">
           <stringProp name="HTTPSampler.domain">${thunder_host}</stringProp>
           <stringProp name="HTTPSampler.port">${thunder_port}</stringProp>


### PR DESCRIPTION
## Summary

Updates the Azure DevOps perf test harness so it deploys and exercises Thunder v0.47.0 end to end. The Install Thunder step now completes with healthy pods, bootstrap seeds the default resources (including the CONSOLE app and admin user), and the Populate Test Data step obtains an admin token and seeds applications and users.

## Changes

- Default the Thunder image tag to `0.47.0` and update the Helm install for v0.47.0 compatibility.
- Make the setup job root filesystem writable so `mktemp` in `setup.sh` works during bootstrap.
- Disable the bundled consent (OpenFGC) server for the perf environment. The perf scenarios do not use consent, and it was the source of repeated bootstrap and deploy failures.
- Send a console redirect URI that matches the seeded CONSOLE app (`https://<host>/console`) in the test data setup, so the admin token flow is not rejected with "Invalid redirect URI".
- Wait for Thunder readiness and dump pod, service, endpoint, ingress, and setup/bootstrap job logs on install failure, capturing the setup job log live so crash output survives pod deletion.

## Testing

- Install Thunder: release deployed, both Thunder pods `1/1 Running` with real service endpoints.
- Populate Test Data: admin token flow succeeds, applications and users seeded.
- Perf scenarios run against the deployment with real traffic.