### PR TITLE
Update Run Performance Test pipeline defaults to match with Thunder repo renaming

### DIFF
--- a/kubernetes/azure/devops-pipelines/perf-test-execution.yaml
+++ b/kubernetes/azure/devops-pipelines/perf-test-execution.yaml
@@ -37,15 +37,15 @@ parameters:
   - name: THUNDER_IMAGE_REGISTRY
     displayName: Thunder Image Registry
     type: string
-    default: "ghcr.io/asgardeo"
+    default: "ghcr.io/thunder-id"
   - name: THUNDER_IMAGE_REPOSITORY
     displayName: Thunder Image Repository
     type: string
-    default: "thunder"
+    default: "thunderid"
   - name: THUNDER_IMAGE_TAG
     displayName: Thunder Image Tag
     type: string
-    default: "0.7.0"
+    default: "0.47.0"
   - name: PERFORMANCE_REPO
     displayName: Performance repo name
     type: string
@@ -57,7 +57,7 @@ parameters:
   - name: THUNDER_HELM_REPO
     type: string
     displayName: "Thunder Helm Repository"
-    default: "asgardeo/thunder"
+    default: "thunder-id/thunderid"
   - name: THUNDER_HELM_REPO_BRANCH
     type: string
     displayName: "Thunder Helm Repository Branch"


### PR DESCRIPTION
### Summary

The **Run Performance Test** pipeline (`kubernetes/azure/devops-pipelines/perf-test-execution.yaml`) still carried the pre-rebranding `asgardeo/thunder` default values. It was missed when the other pipeline defaults were updated during the Thunder repo renaming (commit 20bca84), so Azure runs started from stale defaults.

### Changes

Updated the parameter defaults to match the renamed repo:

| Parameter | Before | After |
|---|---|---|
| `THUNDER_IMAGE_REGISTRY` | `ghcr.io/asgardeo` | `ghcr.io/thunder-id` |
| `THUNDER_IMAGE_REPOSITORY` | `thunder` | `thunderid` |
| `THUNDER_IMAGE_TAG` | `0.7.0` | `0.47.0` |
| `THUNDER_HELM_REPO` | `asgardeo/thunder` | `thunder-id/thunderid` |

`PERFORMANCE_REPO` was already correct (`asgardeo/thunder-performance`).
