### PR TITLE
Fix AWS VM performance test suite for Thunder 1.0.0-alpha

### DIFF
--- a/perf-scripts/common/deployment/setup/resources/postgres/create_database.sql
+++ b/perf-scripts/common/deployment/setup/resources/postgres/create_database.sql
@@ -15,16 +15,16 @@
 -- under the License.
 
 create database "configdb";
-create database "runtimedb";
-create database "userdb";
-create database "operationdb";
+create database "runtime_transient";
+create database "entitydb";
+create database "runtime_persistent";
 
 \c configdb
 \i /home/ubuntu/thunder/dbscripts/configdb/postgres.sql
-\c runtimedb
-\i /home/ubuntu/thunder/dbscripts/runtimedb/postgres.sql
-\c userdb
-\i /home/ubuntu/thunder/dbscripts/userdb/postgres.sql
-\c operationdb
-\i /home/ubuntu/thunder/dbscripts/operationdb/postgres.sql
+\c runtime_transient
+\i /home/ubuntu/thunder/dbscripts/runtime_transient/postgres.sql
+\c entitydb
+\i /home/ubuntu/thunder/dbscripts/entitydb/postgres.sql
+\c runtime_persistent
+\i /home/ubuntu/thunder/dbscripts/runtime_persistent/postgres.sql
 

--- a/perf-scripts/common/deployment/setup/update-thunder-conf.sh
+++ b/perf-scripts/common/deployment/setup/update-thunder-conf.sh
@@ -104,7 +104,12 @@ echo "-------------------------------------------"
 cd "$carbon_home"
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 LOG_FILE="thunder_setup_${TIMESTAMP}.log"
-bash setup.sh > "$LOG_FILE" 2>&1 &
+# Pin the bootstrapped admin credentials (override via ADMIN_USERNAME/ADMIN_PASSWORD env).
+# Since Thunder v1.0.0-alpha, setup.sh generates a random admin password when none is
+# supplied, which breaks the JMeter admin-token seeding flow (it logs in as admin/admin).
+# Keep these in sync with adminUsername/adminPassword in the TestData_Thunder_Add_*.jmx
+# seeding plans.
+ADMIN_USERNAME="${ADMIN_USERNAME:-admin}" ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}" bash setup.sh > "$LOG_FILE" 2>&1 &
 cd "../"
 echo "Waiting 60s for Thunder server setup to complete..."
 sleep 60s

--- a/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
+++ b/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
@@ -119,6 +119,11 @@
             <stringProp name="Argument.value">${__P(adminScope,system)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="systemResourceIdentifier" elementType="Argument">
+            <stringProp name="Argument.name">systemResourceIdentifier</stringProp>
+            <stringProp name="Argument.value">${__P(systemResourceIdentifier,https://localhost:8090/mcp)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -210,6 +215,13 @@ log.warn("[SETUP-DEBUG] sampler=[" + label + "] success=" + ok + " responseCode=
                 <stringProp name="Argument.metadata">=</stringProp>
                 <boolProp name="HTTPArgument.use_equals">true</boolProp>
                 <stringProp name="Argument.name">code_challenge_method</stringProp>
+              </elementProp>
+              <elementProp name="resource" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">true</boolProp>
+                <stringProp name="Argument.value">${systemResourceIdentifier}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">resource</stringProp>
               </elementProp>
             </collectionProp>
           </elementProp>
@@ -475,6 +487,13 @@ vars.put('code_challenge', challenge)</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
                 <boolProp name="HTTPArgument.use_equals">true</boolProp>
                 <stringProp name="Argument.name">code_verifier</stringProp>
+              </elementProp>
+              <elementProp name="resource" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">true</boolProp>
+                <stringProp name="Argument.value">${systemResourceIdentifier}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">resource</stringProp>
               </elementProp>
             </collectionProp>
           </elementProp>

--- a/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Users.jmx
+++ b/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Users.jmx
@@ -105,6 +105,11 @@
             <stringProp name="Argument.value">${__P(adminScope,system)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="systemResourceIdentifier" elementType="Argument">
+            <stringProp name="Argument.name">systemResourceIdentifier</stringProp>
+            <stringProp name="Argument.value">${__P(systemResourceIdentifier,https://localhost:8090/mcp)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -196,6 +201,13 @@ log.warn("[SETUP-DEBUG] sampler=[" + label + "] success=" + ok + " responseCode=
                 <stringProp name="Argument.metadata">=</stringProp>
                 <boolProp name="HTTPArgument.use_equals">true</boolProp>
                 <stringProp name="Argument.name">code_challenge_method</stringProp>
+              </elementProp>
+              <elementProp name="resource" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">true</boolProp>
+                <stringProp name="Argument.value">${systemResourceIdentifier}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">resource</stringProp>
               </elementProp>
             </collectionProp>
           </elementProp>
@@ -461,6 +473,13 @@ vars.put('code_challenge', challenge)</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
                 <boolProp name="HTTPArgument.use_equals">true</boolProp>
                 <stringProp name="Argument.name">code_verifier</stringProp>
+              </elementProp>
+              <elementProp name="resource" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">true</boolProp>
+                <stringProp name="Argument.value">${systemResourceIdentifier}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">resource</stringProp>
               </elementProp>
             </collectionProp>
           </elementProp>

--- a/perf-scripts/single-node/setup/resources/deployment.yaml
+++ b/perf-scripts/single-node/setup/resources/deployment.yaml
@@ -49,36 +49,36 @@ database:
           max_open_conns: 20
           max_idle_conns: 20
           conn_max_lifetime: 300
-    runtime:
+    runtime_transient:
         type: "postgres"
         postgres:
           hostname: "{db_hostname}"
           port: 5432
-          name: "runtimedb"
+          name: "runtime_transient"
           username: "asgthunder"
           password: "asgthunder"
           sslmode: "disable"
           max_open_conns: 20
           max_idle_conns: 20
           conn_max_lifetime: 300
-    user:
+    entity:
         type: "postgres"
         postgres:
           hostname: "{db_hostname}"
           port: 5432
-          name: "userdb"
+          name: "entitydb"
           username: "asgthunder"
           password: "asgthunder"
           sslmode: "disable"
           max_open_conns: 20
           max_idle_conns: 20
           conn_max_lifetime: 300
-    operation:
+    runtime_persistent:
         type: "postgres"
         postgres:
           hostname: "{db_hostname}"
           port: 5432
-          name: "operationdb"
+          name: "runtime_persistent"
           username: "asgthunder"
           password: "asgthunder"
           sslmode: "disable"


### PR DESCRIPTION
## Summary

Updates the AWS VM (single-node) performance test suite to work with Thunder `v1.0.0-alpha`, which introduced a set of breaking changes after `v0.48.0`. Validated end to end on AWS (build 332): database setup, test-data seeding, and all three scenarios (client credentials, authorization code, authenticate with credentials) complete with 0% errors.

## Breaking changes addressed

1. **Database rename.** `runtimedb` / `userdb` / `operationdb` were replaced by `runtime_transient` / `entitydb` / `runtime_persistent`, and the `deployment.yaml` database section keys changed to `config` / `runtime_transient` / `entity` / `runtime_persistent`. Updated `create_database.sql` (creating the new databases and loading the matching schema files from the pack's underscore-named `dbscripts` directories) and the single-node `deployment.yaml`.

2. **Admin password is now randomized.** `setup.sh` generates a random admin password when none is supplied, whereas `v0.48.0` defaulted it to `admin`. Pinned `ADMIN_USERNAME` / `ADMIN_PASSWORD` when invoking `setup.sh` so the bootstrapped admin matches the JMeter seeding credentials.

3. **RFC 8707 resource indicator required for the `system` scope.** The admin-token flow requests `scope=system`, which is permission-bearing, so the token endpoint now returns `invalid_target` ("No resource parameter supplied and no default resource server is configured") unless a `resource` is provided. Added the System resource server identifier (`https://localhost:8090/mcp`, overridable via the `systemResourceIdentifier` property) as the `resource` parameter on both the authorize and token requests in the seeding scripts.

## Files changed

- `perf-scripts/common/deployment/setup/resources/postgres/create_database.sql`
- `perf-scripts/single-node/setup/resources/deployment.yaml`
- `perf-scripts/common/deployment/setup/update-thunder-conf.sh`
- `perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx`
- `perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Users.jmx`

## Testing

Run against this branch on AWS (single-node, postgres, 50 concurrent users):

- DB creation: all four databases created and schemas loaded.
- Seeding: `Add_Applications` and `Add_Users` both 0% errors.
- Scenario 00 client_credentials: 86,140 requests, 0 errors.
- Scenario 01 authorization_code: 7,145 requests, 0 errors.
- Scenario 02 authenticate_with_credentials: 86,455 requests, 0 errors.
