### PR TITLE
Bump AKS Kubernetes version to 1.34 for Azure perf tests

### DIFF
--- a/kubernetes/azure/terraform/conf/thunder.conf.tfvars
+++ b/kubernetes/azure/terraform/conf/thunder.conf.tfvars
@@ -22,7 +22,7 @@ padding              = "001"
 
 # AKS configuration
 
-kubernetes_version             = "1.33"
+kubernetes_version             = "1.34"
 default_node_pool_vm_size      = "Standard_F8s_v2"
 default_node_pool_count        = 2
 default_node_pool_os_disk_size = 64


### PR DESCRIPTION
## Purpose

The `Create Terraform` build for the Azure perf environment started failing at the AKS cluster creation step:

```
Error: creating Kubernetes Cluster ... unexpected status 400 (400 Bad Request)
"code": "K8sVersionNotSupported",
"message": "Managed cluster ... is on version 1.33.13, which is only available for
Long-Term Support (LTS). ... use [az aks get-versions] command to get the supported
version list in this region."
```

The Terraform config pinned `kubernetes_version = "1.33"`, which resolves to its latest patch (`1.33.13`). This passed previously because 1.33 was on the standard channel, but Azure has since retired 1.33 from the standard channel in `eastus2` (it is now offered only under Long-Term Support, which requires the Premium tier and the AKSLongTermSupport plan). All other resources (Postgres servers, VM, networking) provision fine; only the AKS cluster fails.

## Changes

- `thunder.conf.tfvars`: bump `kubernetes_version` from `1.33` to `1.34` (a currently supported standard-channel version in `eastus2`).

## Notes

Verify the target version is listed for the region before merging:

```
az aks get-versions --location eastus2 --output table
```