### PR TITLE
Fix performance test suite for Thunder 1.0.0-alpha2 breaking changes

### DIFF
--- a/perf-scripts/common/jmeter/oauth/Thunder_OAuth_Authorization_Code_Grant.jmx
+++ b/perf-scripts/common/jmeter/oauth/Thunder_OAuth_Authorization_Code_Grant.jmx
@@ -47,6 +47,7 @@
           <elementProp name="scope" elementType="Argument">
             <stringProp name="Argument.name">scope</stringProp>
             <stringProp name="Argument.value">openid</stringProp>
+            <stringProp name="Argument.desc">Keep this OIDC-only. Since Thunder v1.0.0-alpha2 a permission bearing authorize request without a resource parameter is rejected with invalid_target unless a default resource server is configured.</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
           <elementProp name="callbackUrl" elementType="Argument">
@@ -233,7 +234,7 @@ if (y == 0 || &quot;active-passive&quot;.equals(deploymentType)) {
               </elementProp>
               <elementProp name="scope" elementType="HTTPArgument">
                 <boolProp name="HTTPArgument.always_encode">true</boolProp>
-                <stringProp name="Argument.value">${scope}%20${__Random(1,10000000)}</stringProp>
+                <stringProp name="Argument.value">${scope}</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
                 <boolProp name="HTTPArgument.use_equals">true</boolProp>
                 <stringProp name="Argument.name">scope</stringProp>

--- a/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
+++ b/perf-scripts/common/jmeter/setup/TestData_Thunder_Add_Applications.jmx
@@ -45,6 +45,12 @@
             <stringProp name="Argument.value">https://localhost/callback</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="applicationType" elementType="Argument">
+            <stringProp name="Argument.name">applicationType</stringProp>
+            <stringProp name="Argument.value">${__P(applicationType,custom)}</stringProp>
+            <stringProp name="Argument.desc">Application type. Required on creation since Thunder v1.0.0-alpha2.</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -842,6 +848,7 @@ if (y == 0) {
     &quot;ouId&quot;: &quot;${__property(default_org_id)}&quot;,&#xd;
     &quot;name&quot;: &quot;${applicationNamePrefix}${application_count_id}&quot;,&#xd;
     &quot;description&quot;: &quot;Initial testing App&quot;,&#xd;
+    &quot;type&quot;: &quot;${applicationType}&quot;,&#xd;
     &quot;authFlowId&quot;: &quot;${__property(custom_flow_id)}&quot;,&#xd;
     &quot;inboundAuthConfig&quot;: [&#xd;
         {&#xd;


### PR DESCRIPTION
## Summary

Fixes the VM performance test suite for the breaking changes introduced in Thunder 1.0.0-alpha2. The suite worked against 1.0.0-alpha but fails during test data seeding on alpha2.

## Changes

- Send the newly required `type` field when registering applications. Since alpha2, `POST /applications` requires `type` with no implicit default, so every seeding request failed with `400 APP-1042 "Application type is required"` and the run aborted before any scenario executed. The value is `custom` (the documented catch-all), overridable with `-JapplicationType`. The seeded application uses both `authorization_code` and `client_credentials`, so it fits no single platform class, and alpha2 derives flow initiation for `custom` applications from the OAuth profile exactly as alpha1 did when no type existed.
- Request only OIDC scopes in the authorization code grant scenario. The scenario appended a random value to the scope (`openid <random>`), which alpha2 treats as a permission bearing request and rejects at `/oauth2/authorize` with `invalid_target` ("No resource parameter supplied and no default resource server is configured") when no resource is bound. This was the next failure after seeding.

## Verification

Ran the JMeter test plans against a local Thunder 1.0.0-alpha2 server, before and after the fix:

| Test plan | Before | After |
| --- | --- | --- |
| `TestData_Thunder_Add_Applications` | 77.78% errors | 0.00% |
| `Thunder_OAuth_Authorization_Code_Grant` | 57.14% errors | 0.00% |
| `TestData_Thunder_Add_Users` | 0.00% | 0.00% |
| `Thunder_OAuth_Client_Credentials_Grant` | 0.00% | 0.00% |
| `Authenticate_With_Credentials` | 0.00% | 0.00% |

Both behaviours were also confirmed as regressions by replaying the same requests against a 1.0.0-alpha server, where they succeed. The `deployment.yaml` shipped in the pack is unchanged between alpha1 and alpha2, so the perf deployment config needs no update.
