### PR TITLE
Expose AKS node pool, perf runner VM, Thunder HPA, and nginx sizing as pipeline parameters

### DIFF
--- a/kubernetes/azure/README.md
+++ b/kubernetes/azure/README.md
@@ -162,6 +162,18 @@ Execute the pipeline with the `destroy` action to remove all previously provisio
 | Terraform Action | The infrastructure operation to perform  | `create`, `destroy` | `create` |
 | Terraform Performance Repository | Repository containing the Terraform code | String              | asgardeo/thunder-performance |
 | Terraform Performance Repository Branch | Branch of the repository to use          | String              | main |
+| Config PostgreSQL Server SKU | SKU of the config database server | `GP_Standard_D2s_v3`, `GP_Standard_D4s_v3`, `GP_Standard_D8s_v3`, `GP_Standard_D16s_v3` | `GP_Standard_D2s_v3` |
+| Runtime PostgreSQL Server SKU | SKU of the runtime database server | Same as above | `GP_Standard_D2s_v3` |
+| User PostgreSQL Server SKU | SKU of the user database server | Same as above | `GP_Standard_D2s_v3` |
+| AKS Node Pool VM Size | VM size of the AKS default node pool | `Standard_F8s_v2`, `Standard_F16s_v2`, `Standard_F32s_v2`, `Standard_F64s_v2` | `Standard_F8s_v2` |
+| AKS Node Pool Node Count | Number of nodes in the node pool | Number | `2` |
+| AKS Node Pool Min Node Count (autoscale) | Autoscaler lower bound | Number | `2` |
+| AKS Node Pool Max Node Count (autoscale) | Autoscaler upper bound | Number | `5` |
+| AKS Max Pods Per Node | Maximum pods schedulable on each node | Number | `30` |
+| Perf Runner (JMeter Client) VM Size | VM size of the perf runner VM, which is where JMeter executes | `Standard_F8s_v2`, `Standard_F16s_v2`, `Standard_F32s_v2`, `Standard_F64s_v2`, `Standard_F72s_v2` | `Standard_F8s_v2` |
+
+> **Note:** Changing the AKS Node Pool VM Size replaces the node pool, so the cluster is rebuilt on
+> apply. See [Sizing the environment for high concurrency](#sizing-the-environment-for-high-concurrency).
 
 ### Deploy Thunder Pipeline
 
@@ -184,11 +196,26 @@ This pipeline deploys Thunder to the provisioned AKS cluster through a series of
 | Setup Database Schema | Enable/disable database schema creation | `true`, `false` | `true` |
 | Install Thunder | Enable/disable Thunder deployment       | `true`, `false` | `true` |
 | Add Hosts Entry to VM | Enable/disable hosts file configuration | `true`, `false` | `true` |
-| Terraform Repository | Repository containing Thunder           | String          | asgardeo/thunder-performance |
-| Terraform Repository Branch | Branch of the repository to use         | String          | main |
-| Thunder Image Registry | Docker registry for Thunder image       | String          | ghcr.io/asgardeo |
-| Thunder Image Repository | Docker repository for Thunder image     | String          | thunder |
-| Thunder Image Tag | Docker image tag for Thunder            | String          | 0.7.0 |
+| Populate Test Data | Enable/disable seeding of test applications and users | `true`, `false` | `true` |
+| Thunder Repository | Repository containing the Thunder Helm chart | String          | thunder-id/thunderid |
+| Thunder Repository Branch | Branch of the Thunder repository to use | String          | main |
+| Performance repo name | Repository containing performance tests | String          | asgardeo/thunder-performance |
+| Performance repo branch | Branch of the performance repository    | String          | main |
+| Thunder Image Registry | Docker registry for Thunder image       | String          | ghcr.io/thunder-id |
+| Thunder Image Repository | Docker repository for Thunder image     | String          | thunderid |
+| Thunder Image Tag | Docker image tag for Thunder            | String          | 1.0.0-alpha |
+| Nginx Replicas (also the HPA minimum) | Nginx controller replica count and HPA lower bound | Number | `2` |
+| Nginx HPA Max Replicas | Nginx HPA upper bound | Number | `5` |
+| Nginx CPU Limits | CPU limit per Nginx pod | String (e.g. `1000m`, `4`) | `1000m` |
+| Nginx CPU Requests | CPU request per Nginx pod | String (e.g. `500m`, `4`) | `500m` |
+| Nginx Memory Limits | Memory limit per Nginx pod | String (e.g. `1000Mi`, `4Gi`) | `1000Mi` |
+| Nginx Memory Requests | Memory request per Nginx pod | String (e.g. `500Mi`, `4Gi`) | `500Mi` |
+| Nginx HPA Target CPU Utilization (%) | CPU threshold that triggers Nginx scale-out | Number | `80` |
+| Nginx HPA Target Memory Utilization (%) | Memory threshold that triggers Nginx scale-out | Number | `80` |
+
+> **Note:** Nginx fronts every request, so it saturates before Thunder does at high concurrency.
+> Scale it alongside the Thunder pods and the node pool. See
+> [Sizing the environment for high concurrency](#sizing-the-environment-for-high-concurrency).
 
 ### Run Performance Test Pipeline
 
@@ -204,19 +231,83 @@ This pipeline executes the performance tests against the deployed Thunder instan
 
 | Parameter Name | Description                                                                                                                                  | Accepted Values | Default Value                    |
 |----------------|----------------------------------------------------------------------------------------------------------------------------------------------|-----------------|----------------------------------|
-| Scale Up Perf Environment | Enable/disable environment scaling up                                                                                                        | `true`, `false` | `true`                           |
+| Scale Up Perf Environment | Enable/disable environment scaling up                                                                                                        | `true`, `false` | `false`                          |
 | Execute Performance Test | Enable/disable test execution                                                                                                                | `true`, `false` | `true`                           |
-| Scale Down Perf Environment | Enable/disable environment scaling down                                                                                                      | `true`, `false` | `true`                           |
+| Scale Down Perf Environment | Enable/disable environment scaling down                                                                                                      | `true`, `false` | `false`                          |
 | Performance repo name | Repository containing performance tests                                                                                                      | String          | asgardeo/thunder-performance     |
-| Performance repo branch | Branch of the performance repository                                                                                                         | String          | thunder                          |
-| Concurrency | User load configuration                                                                                                                      | Number          | `200`                            |
+| Performance repo branch | Branch of the performance repository                                                                                                         | String          | main                             |
+| Thunder Helm Repository | Repository containing the Thunder Helm chart                                                                                                 | String          | thunder-id/thunderid             |
+| Thunder Helm Repository Branch | Branch of the Helm repository                                                                                                           | String          | main                             |
+| Concurrency | Number of concurrent users to drive                                                                                                          | Number          | `200`                            |
+| Test Duration (minutes) | Measurement window per scenario                                                                                                              | Number          | `3`                              |
+| Warm-up Time (minutes) | Warm-up window discarded before measurement                                                                                                  | Number          | `2`                              |
+| Enable delays in testing | Applies a 6000ms +/- 2000ms think-time timer between Authorization Code iterations. Turn this **off** to measure maximum throughput           | `true`, `false` | `true`                           |
 | Perf-Test purpose | Test run description for reporting                                                                                                           | String          | Regular Thunder performance test |
-| Run Mode | Test execution scope                                                                                                                         | `QUICK`, `FULL` | `QUICK`                          |
-| Populate test data | Enable/disable test data population. This should be executed as true when the test is executed for the first time after environment creation | `true`, `false` | `false`                          |
-| Thunder Image Registry | Docker registry for Thunder image       | String          | ghcr.io/asgardeo |
-| Thunder Image Repository | Docker repository for Thunder image     | String          | thunder |
-| Thunder Image Tag | Docker image tag for Thunder            | String          | 0.7.0 |
+| Thunder Replicas | Initial Thunder pod count and HPA minimum                                                                                                    | Number          | `2`                              |
+| Thunder CPU Limits | CPU limit per Thunder pod                                                                                                                    | String          | `1.5`                            |
+| Thunder CPU Requests | CPU request per Thunder pod                                                                                                                  | String          | `1`                              |
+| Thunder Memory Limits | Memory limit per Thunder pod                                                                                                                 | String          | `512Mi`                          |
+| Thunder Memory Requests | Memory request per Thunder pod                                                                                                               | String          | `256Mi`                          |
+| Thunder HPA Enabled | Enable/disable Thunder autoscaling                                                                                                           | `true`, `false` | `true`                           |
+| Thunder HPA Max Replicas | Ceiling on total Thunder pods, and therefore on total Thunder capacity                                                                  | Number          | `10`                             |
+| Thunder HPA Target CPU Utilization (%) | CPU threshold that triggers Thunder scale-out                                                                                  | Number          | `65`                             |
+| Thunder HPA Target Memory Utilization (%) | Memory threshold that triggers Thunder scale-out                                                                            | Number          | `75`                             |
+| Thunder Image Registry | Docker registry for Thunder image       | String          | ghcr.io/thunder-id |
+| Thunder Image Repository | Docker repository for Thunder image     | String          | thunderid |
+| Thunder Image Tag | Docker image tag for Thunder            | String          | 0.47.0 |
 
+
+## Sizing the environment for high concurrency
+
+The defaults are sized for low-concurrency smoke runs (a 2-node `Standard_F8s_v2` pool). Driving
+1000 or 10000 concurrent users requires scaling four things together. Raising any one of them
+alone will not help, because whichever is left small becomes the bottleneck.
+
+| Layer | Pipeline | Parameters |
+|-------|----------|------------|
+| AKS node pool | Execute Terraform | AKS Node Pool VM Size, Node Count, Min/Max Node Count |
+| Load generator | Execute Terraform | Perf Runner (JMeter Client) VM Size |
+| Thunder pods | Run Performance Test | Thunder Replicas, CPU/Memory Limits and Requests, HPA Max Replicas |
+| Nginx ingress | Deploy Thunder | Nginx Replicas, HPA Max Replicas, CPU/Memory Limits and Requests |
+
+### What to watch for
+
+- **The load generator is a common bottleneck.** JMeter runs on the single perf runner VM. If it
+  runs out of CPU or ephemeral ports, the run reports huge error rates that look like a Thunder
+  failure but are not. Check `jmeter_loadavg.txt` and `jmeter_ss.txt` in the results archive: a
+  load average far above the VM's vCPU count, or most sockets sitting in `TIME_WAIT`, means the
+  client was the limit and the numbers are not usable.
+- **The HPA ceiling must fit on the node pool.** Thunder can only scale to `HPA Max Replicas` if
+  the pool has room for that many pods at the configured CPU/memory requests, alongside Nginx and
+  the system pods. Multiply pods by requested CPU and compare against the pool's total allocatable
+  CPU before raising the ceiling.
+- **Nginx sees every request**, so it needs to grow with Thunder. The defaults of 1 vCore and a
+  maximum of 5 pods will cap throughput well before Thunder does.
+- **Turn off "Enable delays in testing" to measure maximum throughput.** With it on, the
+  Authorization Code scenario spends roughly 6 seconds of every iteration in a think-time timer,
+  so its throughput reflects the timer rather than the server. Client Credentials and User
+  Authentication have no such timer. Benchmarks run with different settings are not comparable.
+
+### Reference configuration
+
+The v0.40.0 10000-user runs used the following. Sizes are given as the pipeline parameter values.
+
+| Parameter | Value |
+|-----------|-------|
+| AKS Node Pool VM Size / Node Count | `Standard_F32s_v2` / `5` |
+| Perf Runner VM Size | `Standard_F64s_v2` or larger |
+| Config / Runtime / User PostgreSQL SKU | `GP_Standard_D8s_v3` |
+| Thunder Replicas | `15` |
+| Thunder CPU Limits / Requests | `4` / `4` |
+| Thunder Memory Limits / Requests | `2Gi` / `2Gi` |
+| Thunder HPA Max Replicas | `32` |
+| Nginx Replicas / HPA Max Replicas | `7` / `10` |
+| Nginx CPU Limits / Requests | `4` / `4` |
+| Nginx Memory Limits / Requests | `4Gi` / `4Gi` |
+| Enable delays in testing | off |
+
+Recorded results are under [`benchmarks/`](../../benchmarks), with the exact specification for each
+run in that run's `readme.md`.
 
 ## Additional Resources
 

--- a/kubernetes/azure/devops-pipelines/deploy-thunder.yaml
+++ b/kubernetes/azure/devops-pipelines/deploy-thunder.yaml
@@ -71,6 +71,40 @@ parameters:
     displayName: Thunder Image Tag
     type: string
     default: "1.0.0-alpha"
+  # Nginx fronts every request, so it becomes the bottleneck before Thunder does at high
+  # concurrency unless it is scaled alongside the Thunder pods and the AKS node pool.
+  - name: NGINX_REPLICAS
+    displayName: Nginx Replicas (also the HPA minimum)
+    type: string
+    default: '2'
+  - name: NGINX_MAX_REPLICAS
+    displayName: Nginx HPA Max Replicas
+    type: string
+    default: '5'
+  - name: NGINX_CPU_LIMITS
+    displayName: Nginx CPU Limits
+    type: string
+    default: '1000m'
+  - name: NGINX_CPU_REQUESTS
+    displayName: Nginx CPU Requests
+    type: string
+    default: '500m'
+  - name: NGINX_MEMORY_LIMITS
+    displayName: Nginx Memory Limits
+    type: string
+    default: '1000Mi'
+  - name: NGINX_MEMORY_REQUESTS
+    displayName: Nginx Memory Requests
+    type: string
+    default: '500Mi'
+  - name: NGINX_TARGET_CPU_UTILIZATION
+    displayName: Nginx HPA Target CPU Utilization (%)
+    type: string
+    default: '80'
+  - name: NGINX_TARGET_MEMORY_UTILIZATION
+    displayName: Nginx HPA Target Memory Utilization (%)
+    type: string
+    default: '80'
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -116,6 +150,14 @@ jobs:
         parameters:
           LB_INTERNAL_IP: $(INTERNAL_NGINX_CONTROLLER_LB_INTERNAL_IP)
           LB_INTERNAL_SUBNET: $(INTERNAL_NGINX_CONTROLLER_LB_INTERNAL_SUBNET)
+          NO_OF_REPLICAS: ${{ parameters.NGINX_REPLICAS }}
+          MAX_REPLICAS: ${{ parameters.NGINX_MAX_REPLICAS }}
+          NGINX_CPU_LIMITS: ${{ parameters.NGINX_CPU_LIMITS }}
+          NGINX_CPU_REQUESTS: ${{ parameters.NGINX_CPU_REQUESTS }}
+          NGINX_MEMORY_LIMITS: ${{ parameters.NGINX_MEMORY_LIMITS }}
+          NGINX_MEMORY_REQUESTS: ${{ parameters.NGINX_MEMORY_REQUESTS }}
+          TARGET_CPU_UTILIZATION: ${{ parameters.NGINX_TARGET_CPU_UTILIZATION }}
+          TARGET_MEMORY_UTILIZATION: ${{ parameters.NGINX_TARGET_MEMORY_UTILIZATION }}
 
   - job: setup_db_schema
     displayName: Setup Database Schema

--- a/kubernetes/azure/devops-pipelines/execute-terraform.yaml
+++ b/kubernetes/azure/devops-pipelines/execute-terraform.yaml
@@ -64,6 +64,44 @@ parameters:
       - "GP_Standard_D4s_v3"
       - "GP_Standard_D8s_v3"
       - "GP_Standard_D16s_v3"
+  # Changing the node pool VM size replaces the node pool, so the cluster is rebuilt on apply.
+  - name: AKS_NODE_POOL_VM_SIZE
+    type: string
+    displayName: "AKS Node Pool VM Size"
+    default: "Standard_F8s_v2"
+    values:
+      - "Standard_F8s_v2"
+      - "Standard_F16s_v2"
+      - "Standard_F32s_v2"
+      - "Standard_F64s_v2"
+  - name: AKS_NODE_POOL_COUNT
+    type: number
+    displayName: "AKS Node Pool Node Count"
+    default: 2
+  - name: AKS_NODE_POOL_MIN_COUNT
+    type: number
+    displayName: "AKS Node Pool Min Node Count (autoscale)"
+    default: 2
+  - name: AKS_NODE_POOL_MAX_COUNT
+    type: number
+    displayName: "AKS Node Pool Max Node Count (autoscale)"
+    default: 5
+  - name: AKS_NODE_POOL_MAX_PODS
+    type: number
+    displayName: "AKS Max Pods Per Node"
+    default: 30
+  # The perf runner (bastion) VM is where JMeter executes. Undersizing it makes the load
+  # generator, rather than Thunder, the bottleneck at high concurrency.
+  - name: PERF_RUNNER_VM_SIZE
+    type: string
+    displayName: "Perf Runner (JMeter Client) VM Size"
+    default: "Standard_F8s_v2"
+    values:
+      - "Standard_F8s_v2"
+      - "Standard_F16s_v2"
+      - "Standard_F32s_v2"
+      - "Standard_F64s_v2"
+      - "Standard_F72s_v2"
 
 variables:
   - group: vg-thunder-perf
@@ -300,6 +338,12 @@ stages:
                   -var="postgres_config_server_sku_name=${{ parameters.POSTGRES_CONFIG_SERVER_SKU }}" \
                   -var="postgres_runtime_server_sku_name=${{ parameters.POSTGRES_RUNTIME_SERVER_SKU }}" \
                   -var="postgres_user_server_sku_name=${{ parameters.POSTGRES_USER_SERVER_SKU }}" \
+                  -var="default_node_pool_vm_size=${{ parameters.AKS_NODE_POOL_VM_SIZE }}" \
+                  -var="default_node_pool_count=${{ parameters.AKS_NODE_POOL_COUNT }}" \
+                  -var="default_node_pool_min_count=${{ parameters.AKS_NODE_POOL_MIN_COUNT }}" \
+                  -var="default_node_pool_max_count=${{ parameters.AKS_NODE_POOL_MAX_COUNT }}" \
+                  -var="default_node_pool_max_pods=${{ parameters.AKS_NODE_POOL_MAX_PODS }}" \
+                  -var="vm_size=${{ parameters.PERF_RUNNER_VM_SIZE }}" \
                   -auto-approve
             env:
               ARM_CLIENT_ID: $(ARM_CLIENT_ID)
@@ -326,6 +370,12 @@ stages:
                   -var="postgres_config_server_sku_name=${{ parameters.POSTGRES_CONFIG_SERVER_SKU }}" \
                   -var="postgres_runtime_server_sku_name=${{ parameters.POSTGRES_RUNTIME_SERVER_SKU }}" \
                   -var="postgres_user_server_sku_name=${{ parameters.POSTGRES_USER_SERVER_SKU }}" \
+                  -var="default_node_pool_vm_size=${{ parameters.AKS_NODE_POOL_VM_SIZE }}" \
+                  -var="default_node_pool_count=${{ parameters.AKS_NODE_POOL_COUNT }}" \
+                  -var="default_node_pool_min_count=${{ parameters.AKS_NODE_POOL_MIN_COUNT }}" \
+                  -var="default_node_pool_max_count=${{ parameters.AKS_NODE_POOL_MAX_COUNT }}" \
+                  -var="default_node_pool_max_pods=${{ parameters.AKS_NODE_POOL_MAX_PODS }}" \
+                  -var="vm_size=${{ parameters.PERF_RUNNER_VM_SIZE }}" \
                   -auto-approve
 
                 # Then destroy the rest of the resources
@@ -335,6 +385,12 @@ stages:
                   -var="postgres_config_server_sku_name=${{ parameters.POSTGRES_CONFIG_SERVER_SKU }}" \
                   -var="postgres_runtime_server_sku_name=${{ parameters.POSTGRES_RUNTIME_SERVER_SKU }}" \
                   -var="postgres_user_server_sku_name=${{ parameters.POSTGRES_USER_SERVER_SKU }}" \
+                  -var="default_node_pool_vm_size=${{ parameters.AKS_NODE_POOL_VM_SIZE }}" \
+                  -var="default_node_pool_count=${{ parameters.AKS_NODE_POOL_COUNT }}" \
+                  -var="default_node_pool_min_count=${{ parameters.AKS_NODE_POOL_MIN_COUNT }}" \
+                  -var="default_node_pool_max_count=${{ parameters.AKS_NODE_POOL_MAX_COUNT }}" \
+                  -var="default_node_pool_max_pods=${{ parameters.AKS_NODE_POOL_MAX_PODS }}" \
+                  -var="vm_size=${{ parameters.PERF_RUNNER_VM_SIZE }}" \
                   -auto-approve
             env:
               ARM_CLIENT_ID: $(ARM_CLIENT_ID)

--- a/kubernetes/azure/devops-pipelines/perf-test-execution.yaml
+++ b/kubernetes/azure/devops-pipelines/perf-test-execution.yaml
@@ -102,6 +102,20 @@ parameters:
     displayName: Thunder HPA Enabled
     type: boolean
     default: true
+  # The HPA ceiling caps total Thunder capacity. Raising it only helps if the node pool has
+  # room to schedule the extra pods, so scale the AKS node pool along with it.
+  - name: THUNDER_HPA_MAX_REPLICAS
+    displayName: Thunder HPA Max Replicas
+    type: string
+    default: '10'
+  - name: THUNDER_HPA_CPU_UTILIZATION
+    displayName: Thunder HPA Target CPU Utilization (%)
+    type: string
+    default: '65'
+  - name: THUNDER_HPA_MEMORY_UTILIZATION
+    displayName: Thunder HPA Target Memory Utilization (%)
+    type: string
+    default: '75'
   - name: BUILD_PURPOSE
     displayName: Perf-Test purpose
     type: string
@@ -129,6 +143,12 @@ variables:
     value: ${{parameters.THUNDER_MEMORY_LIMITS}}
   - name: THUNDER_MEMORY_REQUESTS
     value: ${{parameters.THUNDER_MEMORY_REQUESTS}}
+  - name: THUNDER_HPA_MAX_REPLICAS
+    value: ${{parameters.THUNDER_HPA_MAX_REPLICAS}}
+  - name: THUNDER_HPA_CPU_UTILIZATION
+    value: ${{parameters.THUNDER_HPA_CPU_UTILIZATION}}
+  - name: THUNDER_HPA_MEMORY_UTILIZATION
+    value: ${{parameters.THUNDER_HPA_MEMORY_UTILIZATION}}
   - name: THUNDER_HPA_ENABLED
     ${{ if eq(parameters.THUNDER_HPA_ENABLED, true) }}:
       value: 'true'

--- a/kubernetes/azure/devops-pipelines/templates/install-nginx.yaml
+++ b/kubernetes/azure/devops-pipelines/templates/install-nginx.yaml
@@ -37,6 +37,27 @@ parameters:
   - name: AUTOSCALING_ENABLED
     type: string
     default: 'true'
+  - name: MAX_REPLICAS
+    type: string
+    default: '5'
+  - name: NGINX_CPU_LIMITS
+    type: string
+    default: '1000m'
+  - name: NGINX_CPU_REQUESTS
+    type: string
+    default: '500m'
+  - name: NGINX_MEMORY_LIMITS
+    type: string
+    default: '1000Mi'
+  - name: NGINX_MEMORY_REQUESTS
+    type: string
+    default: '500Mi'
+  - name: TARGET_CPU_UTILIZATION
+    type: string
+    default: '80'
+  - name: TARGET_MEMORY_UTILIZATION
+    type: string
+    default: '80'
 
 steps:
   - template: ./utils/set-aks-credentials.yaml
@@ -46,17 +67,17 @@ steps:
         replicaCount: ${{ parameters.NO_OF_REPLICAS }}
         resources:
           limits:
-            cpu: 1000m
-            memory: 1000Mi
+            cpu: ${{ parameters.NGINX_CPU_LIMITS }}
+            memory: ${{ parameters.NGINX_MEMORY_LIMITS }}
           requests:
-            cpu: 500m
-            memory: 500Mi
+            cpu: ${{ parameters.NGINX_CPU_REQUESTS }}
+            memory: ${{ parameters.NGINX_MEMORY_REQUESTS }}
         autoscaling:
           enabled: ${{ parameters.AUTOSCALING_ENABLED }}
           minReplicas: ${{ parameters.NO_OF_REPLICAS }}
-          maxReplicas: 5
-          targetCPUUtilizationPercentage: 80
-          targetMemoryUtilizationPercentage: 80
+          maxReplicas: ${{ parameters.MAX_REPLICAS }}
+          targetCPUUtilizationPercentage: ${{ parameters.TARGET_CPU_UTILIZATION }}
+          targetMemoryUtilizationPercentage: ${{ parameters.TARGET_MEMORY_UTILIZATION }}
         service:
           annotations:
             service.beta.kubernetes.io/azure-load-balancer-internal: "true"


### PR DESCRIPTION
Scaling an Azure perf run currently requires editing the repo. The Thunder pod CPU, memory and replica count are already UI parameters, but the settings that actually cap a high-concurrency run are not: the AKS node pool, the JMeter client VM, the HPA ceiling, and nginx. This promotes them to parameters so a scaled run can be triggered from the Run pipeline dialog.

This came out of the 1.0.0-alpha 10000 concurrent user run (#81), which failed with 93-100% error rates. The binding constraints were all in this set.

### `execute-terraform.yaml`

New parameters, passed as `-var` overrides alongside the existing Postgres SKUs in all three terraform invocations (apply and both destroys):

| Parameter | Terraform variable | Default |
|---|---|---|
| AKS Node Pool VM Size | `default_node_pool_vm_size` | `Standard_F8s_v2` |
| AKS Node Pool Node Count | `default_node_pool_count` | `2` |
| AKS Node Pool Min Node Count | `default_node_pool_min_count` | `2` |
| AKS Node Pool Max Node Count | `default_node_pool_max_count` | `5` |
| AKS Max Pods Per Node | `default_node_pool_max_pods` | `30` |
| Perf Runner (JMeter Client) VM Size | `vm_size` | `Standard_F8s_v2` |

VM size fields are dropdowns. The node pool offers F8s_v2 through F64s_v2; the perf runner also offers F72s_v2, which is what the v0.40.0 10000 user runs used.

### `perf-test-execution.yaml`

| Parameter | Helm value | Default |
|---|---|---|
| Thunder HPA Max Replicas | `hpa.maxReplicas` | `10` |
| Thunder HPA Target CPU Utilization (%) | `hpa.averageUtilizationCPU` | `65` |
| Thunder HPA Target Memory Utilization (%) | `hpa.averageUtilizationMemory` | `75` |

These follow the same parameter to variable override pattern already used for `THUNDER_REPLICAS` and the CPU/memory settings, so they take precedence over `variables.yaml` and reach Helm through the existing `--set` flags in `install-thunder.yaml`.

### `deploy-thunder.yaml` and `templates/install-nginx.yaml`

Nginx sizing was previously unreachable: `install-nginx.yaml` declared a `NO_OF_REPLICAS` parameter that `deploy-thunder.yaml` never passed, and the resources, HPA ceiling and utilization targets were hardcoded in the inline Helm values heredoc. The template now takes them as parameters and the deploy pipeline exposes and forwards them.

| Parameter | Helm value | Default |
|---|---|---|
| Nginx Replicas (also the HPA minimum) | `controller.replicaCount` / `autoscaling.minReplicas` | `2` |
| Nginx HPA Max Replicas | `autoscaling.maxReplicas` | `5` |
| Nginx CPU Limits / Requests | `controller.resources` | `1000m` / `500m` |
| Nginx Memory Limits / Requests | `controller.resources` | `1000Mi` / `500Mi` |
| Nginx HPA Target CPU Utilization (%) | `autoscaling.targetCPUUtilizationPercentage` | `80` |
| Nginx HPA Target Memory Utilization (%) | `autoscaling.targetMemoryUtilizationPercentage` | `80` |

This matters because nginx fronts every request, so it saturates before Thunder does at high concurrency. For reference, v0.40.0 ran 7 nginx pods at 4 vCore + 4Gi against the 1 vCore + 1Gi and max 5 that were hardcoded here.

### `kubernetes/azure/README.md`

All three pipeline parameter tables are updated to cover the new fields, plus a new
**Sizing the environment for high concurrency** section explaining that the node pool, load
generator, Thunder pods and Nginx have to be scaled together, how to spot a saturated load
generator in the results archive (`jmeter_loadavg.txt`, `jmeter_ss.txt`), why the HPA ceiling has
to fit on the node pool, and why `USE_DELAYS` makes runs non-comparable. It ends with the
v0.40.0 10000 user configuration as a reference point.

While documenting the new parameters I also corrected stale rows in the same tables: the image
registry/repository/tag defaults, the Scale Up/Down defaults (documented as `true`, actually
`false`), a `Terraform Repository` row that is really the Thunder repository, a `Run Mode` and a
`Populate test data` parameter that no longer exist on the perf test pipeline, and several
existing parameters that were missing entirely (Postgres SKUs, test duration, warm-up, delays,
and the Thunder pod sizing fields).

### Notes

- **All defaults match the current committed values**, so an unmodified run behaves exactly as before. The generated nginx Helm values were rendered with the defaults and are byte-identical to the previous hardcoded block.
- **Changing the node pool VM size replaces the node pool**, meaning the cluster is rebuilt on apply. Noted in a comment above the parameter.
- Raising either HPA ceiling alone will not add capacity unless the node pool has room to schedule the extra pods. Also noted in a comment.
- Template parameter names were cross-checked against what `deploy-thunder.yaml` passes, and the rendered nginx values were validated as YAML with both the defaults and a scaled-up (4 vCore + 4Gi, 7-10 replicas) configuration.
