### PR TITLE
Reinstall Thunder in place for perf runs and capture setup job diagnostics

### DIFF
--- a/kubernetes/azure/devops-pipelines/perf-test-execution.yaml
+++ b/kubernetes/azure/devops-pipelines/perf-test-execution.yaml
@@ -240,6 +240,12 @@ jobs:
           THUNDER_IMAGE_REGISTRY: ${{ parameters.THUNDER_IMAGE_REGISTRY }}
           THUNDER_IMAGE_REPOSITORY: ${{ parameters.THUNDER_IMAGE_REPOSITORY }}
           THUNDER_IMAGE_TAG: ${{ parameters.THUNDER_IMAGE_TAG }}
+          # Reinstall in place. Uninstalling first would make this a fresh install, which re-runs
+          # every pre-install hook: certs-pvc is deleted and recreated (losing crypto.key, which
+          # only setup can regenerate) and the resource bootstrap replays over the existing
+          # database. This job only needs the run's sizing parameters applied, which helm upgrade
+          # does on its own.
+          UNINSTALL_BEFORE_INSTALL: false
 
   - job: thunder_performance_test
     displayName: Thunder performance test

--- a/kubernetes/azure/devops-pipelines/templates/install-thunder.yaml
+++ b/kubernetes/azure/devops-pipelines/templates/install-thunder.yaml
@@ -49,6 +49,7 @@ steps:
         set -e
         SETUP_JOB=${{ parameters.RELEASE_NAME }}-thunderid-setup
         SETUP_LOG=$(mktemp)
+        SETUP_CAPTURE_DIR=$(mktemp -d)
         dump_thunder_diagnostics() {
           echo "##[error]Thunder install did not become ready. Dumping diagnostics:"
           kubectl get pods -n ${{ parameters.NAMESPACE }} -o wide || true
@@ -63,30 +64,64 @@ steps:
           kubectl describe job "$SETUP_JOB" -n ${{ parameters.NAMESPACE }} || true
           # The setup pod is deleted the instant the job hits BackoffLimitExceeded, so a
           # post-hoc "kubectl logs" loses the race. Prefer the log captured live below.
-          echo "--- Setup/bootstrap job logs (captured live) ---"
+          # Snapshot count doubles as proof this template version is the one that ran: zero means
+          # the collector never saw the pod, not that the pod produced no output.
+          echo "--- Setup/bootstrap job logs (captured live, snapshots: $(ls -1 "$SETUP_CAPTURE_DIR" 2>/dev/null | wc -l | tr -d ' ')) ---"
           cat "$SETUP_LOG" 2>/dev/null || true
+          for f in "$SETUP_CAPTURE_DIR"/*; do
+            [ -s "$f" ] || continue
+            echo "--- $(basename "$f") ---"
+            cat "$f"
+          done
           echo "--- Setup/bootstrap job logs (post-hoc, may be empty if pod already deleted) ---"
           kubectl logs job/"$SETUP_JOB" -n ${{ parameters.NAMESPACE }} --all-containers --tail=200 || true
           kubectl logs -n ${{ parameters.NAMESPACE }} -l job-name="$SETUP_JOB" --all-containers --tail=200 || true
           kubectl logs -n ${{ parameters.NAMESPACE }} -l job-name="$SETUP_JOB" --all-containers --previous --tail=200 || true
         }
         trap dump_thunder_diagnostics ERR
-        # Background collector: stream the setup pod's logs to a file while the pre-install
-        # hook runs, so the crash output survives the job controller deleting the failed pod.
+        # Background collector: snapshot the setup pod's logs while the pre-install hook runs, so
+        # the crash output survives the job controller deleting the failed pod. The setup job uses
+        # restartPolicy: OnFailure, so a crashing container spends nearly all of its life in
+        # CrashLoopBackOff; "kubectl logs -f" only blocks there until it times out and captures
+        # nothing. Poll instead, and take --previous as well: once the container has crashed once,
+        # --previous returns the full failing run even while the next attempt is backing off.
         (
-          for _ in $(seq 1 90); do
-            POD=$(kubectl get pods -n ${{ parameters.NAMESPACE }} -l job-name="$SETUP_JOB" \
-              -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
-            if [ -n "$POD" ]; then
-              for p in $POD; do
-                kubectl logs -f "$p" -n ${{ parameters.NAMESPACE }} --all-containers \
-                  --pod-running-timeout=30s >> "$SETUP_LOG" 2>/dev/null || true
+          for _ in $(seq 1 150); do
+            # Match on the pod name prefix rather than a label: "job-name" is deprecated and newer
+            # clusters only set "batch.kubernetes.io/job-name", so a label selector can silently
+            # match nothing. Job pods are always named "<job>-<suffix>".
+            POD=$(kubectl get pods -n ${{ parameters.NAMESPACE }} \
+              -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+              | grep "^$SETUP_JOB-" || true)
+            for p in $POD; do
+              for which in current previous; do
+                [ "$which" = "previous" ] && PREV_FLAG=--previous || PREV_FLAG=
+                OUT="$SETUP_CAPTURE_DIR/$p.$which.log"
+                # Snapshot to a temp file and only promote it when non-empty, so a failed read
+                # after the pod is deleted does not wipe what was already captured.
+                if kubectl logs "$p" -n ${{ parameters.NAMESPACE }} --all-containers $PREV_FLAG \
+                  --tail=-1 > "$OUT.tmp" 2>/dev/null && [ -s "$OUT.tmp" ]; then
+                  mv "$OUT.tmp" "$OUT"
+                fi
+                rm -f "$OUT.tmp"
               done
-            fi
+              # Container-level failures (image pull, missing secret key, mount errors) never
+              # produce logs at all; the pod description is the only place they show up.
+              if kubectl describe pod "$p" -n ${{ parameters.NAMESPACE }} \
+                > "$SETUP_CAPTURE_DIR/$p.describe.txt.tmp" 2>/dev/null; then
+                mv "$SETUP_CAPTURE_DIR/$p.describe.txt.tmp" "$SETUP_CAPTURE_DIR/$p.describe.txt"
+              fi
+              rm -f "$SETUP_CAPTURE_DIR/$p.describe.txt.tmp"
+            done
             sleep 2
           done
         ) &
         SETUP_LOG_COLLECTOR_PID=$!
+        # Record which chart source this run used. deploy-thunder and perf-test-execution check out
+        # the Thunder repo through different parameters, so a mismatch here is otherwise invisible.
+        echo "=== Chart source ==="
+        helm show chart . | grep -E '^(name|version|appVersion):' || true
+        git -C . rev-parse --short HEAD 2>/dev/null || true
         echo "Installing Thunder Helm Chart"
         helm upgrade --install ${{ parameters.RELEASE_NAME }} . \
           --namespace ${{ parameters.NAMESPACE }} \

--- a/kubernetes/azure/devops-pipelines/templates/reinstall-thunder.yaml
+++ b/kubernetes/azure/devops-pipelines/templates/reinstall-thunder.yaml
@@ -32,36 +32,46 @@ parameters:
   - name: THUNDER_IMAGE_TAG
     type: string
     default: '0.7.0'
-  # Reinstall uninstalls Thunder first, which drops the certs PVC holding crypto.key. Setup must
-  # run on the fresh install to regenerate certs/crypto.key, otherwise Thunder crash-loops with
-  # "crypto.key: no such file or directory". Mirrors install-thunder.yaml's default.
+  # Setup must run on any fresh install. certs-pvc carries no hook-delete-policy, so Helm applies
+  # its default of before-hook-creation and deletes/recreates the claim on every install; with a
+  # Delete reclaim policy the file share and crypto.key go with it, and Thunder then crash-loops
+  # with "crypto.key: no such file or directory". Only setup regenerates that key material.
   - name: RUN_SETUP_SCRIPT
+    type: boolean
+    default: true
+  # Uninstalling turns the following step into a fresh install, which re-runs every pre-install
+  # hook: certs-pvc is wiped and regenerated, and the resource bootstrap replays over the existing
+  # database. A perf run needs neither, it only needs the new sizing applied. Left off, the step
+  # becomes an in-place helm upgrade, which skips pre-install hooks and preserves the key material.
+  # Turn it on only to rebuild a release that is beyond repair.
+  - name: UNINSTALL_BEFORE_INSTALL
     type: boolean
     default: true
 
 steps:
   - template: ./utils/set-aks-credentials.yaml
-  - task: AzureCLI@2
-    displayName: 'Uninstall Thunder'
-    inputs:
-      azureSubscription: $(AZURE_SERVICE_CONNECTION_NAME)
-      scriptType: 'bash'
-      scriptLocation: 'inlineScript'
-      workingDirectory: ${{ parameters.WORKING_DIRECTORY }}
-      inlineScript: |
-        if ! helm list -n ${{ parameters.NAMESPACE }} -q --filter "^${{ parameters.RELEASE_NAME }}$" | grep -q "^${{ parameters.RELEASE_NAME }}$"; then
-          echo "Release ${{ parameters.RELEASE_NAME }} not found. Skipping uninstallation."
-          exit 0
-        fi
-        echo "Uninstalling Thunder Helm Chart"
-        if ! helm uninstall ${{ parameters.RELEASE_NAME }} \
-          --namespace ${{ parameters.NAMESPACE }}; then
-          echo "Error: Failed to uninstall Thunder Helm Chart"
-          exit 1
-        fi
-        echo "Waiting for 10 seconds to ensure complete uninstallation"
-        sleep 10
-        echo "Uninstallation completed"
+  - ${{ if eq(parameters.UNINSTALL_BEFORE_INSTALL, true) }}:
+    - task: AzureCLI@2
+      displayName: 'Uninstall Thunder'
+      inputs:
+        azureSubscription: $(AZURE_SERVICE_CONNECTION_NAME)
+        scriptType: 'bash'
+        scriptLocation: 'inlineScript'
+        workingDirectory: ${{ parameters.WORKING_DIRECTORY }}
+        inlineScript: |
+          if ! helm list -n ${{ parameters.NAMESPACE }} -q --filter "^${{ parameters.RELEASE_NAME }}$" | grep -q "^${{ parameters.RELEASE_NAME }}$"; then
+            echo "Release ${{ parameters.RELEASE_NAME }} not found. Skipping uninstallation."
+            exit 0
+          fi
+          echo "Uninstalling Thunder Helm Chart"
+          if ! helm uninstall ${{ parameters.RELEASE_NAME }} \
+            --namespace ${{ parameters.NAMESPACE }}; then
+            echo "Error: Failed to uninstall Thunder Helm Chart"
+            exit 1
+          fi
+          echo "Waiting for 10 seconds to ensure complete uninstallation"
+          sleep 10
+          echo "Uninstallation completed"
 
   - template: ./install-thunder.yaml
     parameters:


### PR DESCRIPTION
## Problem

The `Reinstall Thunder` job in the perf test pipeline failed at the `Install Thunder` step for
Thunder 1.0.0-beta2:

```
Error: failed pre-install: 1 error occurred:
    * job thunder-perf-thunderid-setup failed: BackoffLimitExceeded
```

Two separate issues were in play.

**The reinstall forced a fresh install.** The job uninstalled the release before installing, which
makes Helm re-run every `pre-install` hook. `certs-pvc` carries no `hook-delete-policy`, so Helm
applies its default of `before-hook-creation` and deletes/recreates the claim on each install. With
a Delete reclaim policy the file share goes with it, taking `crypto.key`, after which Thunder
crash-loops with `crypto.key: no such file or directory`. The same fresh install also replays the
resource bootstrap over an already populated database. A perf run needs neither, it only needs the
run's sizing parameters applied.

**The failure was undiagnosable.** The setup job runs with `restartPolicy: OnFailure`, so the job
controller deletes the pod once the backoff limit is reached and any post-hoc `kubectl logs` loses
the race. The existing live collector could not win either: it used `kubectl logs -f
--pod-running-timeout=30s`, which blocks for 30s whenever the container is in CrashLoopBackOff and
so misses the roughly one second per attempt that it is actually running. It also selected pods with
`-l job-name=`, the deprecated Job label that newer clusters no longer set, so on this AKS version
it matched nothing at all.

## Changes

- `reinstall-thunder.yaml` takes a new `UNINSTALL_BEFORE_INSTALL` parameter, default `true` so
  existing callers are unaffected. `perf-test-execution.yaml` passes `false`, turning the reinstall
  into an in-place `helm upgrade`: pre-install hooks are skipped, the key material survives, the
  bootstrap does not replay, and the sizing parameters still apply.
- `install-thunder.yaml` snapshots the setup pod's current and `--previous` logs plus
  `kubectl describe pod` every 2s, promoting each snapshot only when non-empty so the pod's deletion
  cannot wipe what was already captured. The diagnostics header reports the snapshot count, where 0
  means the pod was never seen rather than that it produced no output.
- The setup pod is now located by name prefix instead of the deprecated `job-name` label.
- `install-thunder.yaml` logs the chart name, version, appVersion and checkout commit before
  installing. `deploy-thunder` and `perf-test-execution` reach the Thunder repo through different
  parameters (`THUNDER_REPO_BRANCH` and `THUNDER_HELM_REPO_BRANCH`), so a mismatch between them was
  otherwise invisible in the logs.

## Verification

The perf test pipeline completes against Thunder 1.0.0-beta2 with these changes.

Note that the setup job's underlying failure on a genuine fresh install is not fixed here, only
routed around. Version mismatch, DB schema drift and bootstrap non-idempotency were each ruled out,
since `deploy-thunder` bootstrapped the same populated database successfully with the same chart,
image and values. The diagnostics above are in place to capture the cause the next time a fresh
install runs the hook.
