### PR TITLE
Fix Thunder restart between performance test phases

### DIFF
--- a/perf-scripts/common/thunder/restart-thunder.sh
+++ b/perf-scripts/common/thunder/restart-thunder.sh
@@ -23,25 +23,35 @@ default_carbon_home=$(realpath ~/thunder)
 carbon_home=$default_carbon_home
 default_waiting_time=30
 waiting_time=$default_waiting_time
+default_port=8090
+port=$default_port
+# Grace period for a TERM'd server to exit before it is killed outright.
+stop_timeout=20
+# Settle time after the port starts listening, before the caller drives traffic.
+settle_time=5
 
 function usage() {
     echo ""
     echo "Usage: "
-    echo "$0  [-c <carbon_home>] [-w <waiting_time>]"
+    echo "$0  [-c <carbon_home>] [-w <waiting_time>] [-p <port>]"
     echo ""
     echo "-c: The Thunder path."
-    echo "-w: The waiting time in seconds until the server restart.."
+    echo "-w: The time in seconds to wait for the server to start listening."
+    echo "-p: The port Thunder listens on. Default $default_port."
     echo "-h: Display this help and exit."
     echo ""
 }
 
-while getopts "c:w:h" opts; do
+while getopts "c:w:p:h" opts; do
     case $opts in
     c)
         carbon_home=${OPTARG}
         ;;
     w)
         waiting_time=${OPTARG}
+        ;;
+    p)
+        port=${OPTARG}
         ;;
     h)
         usage
@@ -64,18 +74,111 @@ if [[ -z $waiting_time ]]; then
     exit 1
 fi
 
+# PIDs holding the listen socket on $port. ss is preferred (iproute2 is always present on the
+# perf AMIs); lsof and a name match are fallbacks. Only the current user's processes are
+# visible without root, which is enough since Thunder runs as the same user as this script.
+function listening_pids() {
+    local pids=""
+    if command -v ss >/dev/null 2>&1; then
+        pids=$(ss -lptnH "sport = :$port" 2>/dev/null | grep -oE 'pid=[0-9]+' | cut -d= -f2)
+    fi
+    if [[ -z $pids ]] && command -v lsof >/dev/null 2>&1; then
+        pids=$(lsof -ti "tcp:$port" -sTCP:LISTEN 2>/dev/null)
+    fi
+    if [[ -z $pids ]]; then
+        pids=$(pgrep -f "$carbon_home/thunderid" 2>/dev/null | grep -v "^$$\$")
+    fi
+    # grep keeps this empty when nothing matched, so callers can test with -z.
+    printf '%s\n' $pids | grep -E '^[0-9]+$' | sort -u | tr '\n' ' '
+}
+
+function port_is_free() {
+    local pids
+    pids=$(listening_pids)
+    [[ -z "${pids// /}" ]]
+}
+
+# Stop whatever is on the port. Without this the per-phase restart is a no-op: start.sh exits
+# with "Port 8090 is already in use", and because it is backgrounded nothing notices, so a
+# single server ends up serving every phase of the run.
+function stop_thunder() {
+    local pids
+    pids=$(listening_pids)
+    if [[ -z $pids ]]; then
+        echo "No process is listening on port $port."
+        return 0
+    fi
+
+    echo "Stopping Thunder (PIDs: $pids)..."
+    kill -TERM $pids 2>/dev/null
+
+    local waited=0
+    while ((waited < stop_timeout)); do
+        if port_is_free; then
+            echo "Thunder stopped after ${waited}s."
+            return 0
+        fi
+        sleep 1
+        ((waited++))
+    done
+
+    pids=$(listening_pids)
+    if [[ -n $pids ]]; then
+        echo "Thunder did not exit within ${stop_timeout}s; sending KILL to $pids."
+        kill -KILL $pids 2>/dev/null
+        sleep 2
+    fi
+
+    if ! port_is_free; then
+        echo "ERROR: port $port is still held by '$(listening_pids)' after KILL."
+        return 1
+    fi
+    echo "Thunder stopped."
+}
+
 echo ""
+if ! stop_thunder; then
+    exit 1
+fi
+
+# Drop the previous phase's logs. The old cleanup targeted repository/logs, which Thunder does
+# not use, so thunder_<timestamp>.log was never removed and grew across the whole run. Logs are
+# scp'd off the node in after_execute_test_scenario, so each phase's log is already preserved
+# in that phase's report directory before this runs. The setup log is kept for the whole run.
 echo "Cleaning up any previous log files..."
-rm -rf $carbon_home/repository/logs/*
+rm -rf "$carbon_home"/repository/logs/* 2>/dev/null
+find "$carbon_home" -maxdepth 1 -name 'thunder_*.log' ! -name 'thunder_setup_*.log' -delete 2>/dev/null
 
 echo "Restarting Thunder..."
 cd "$carbon_home"
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 LOG_FILE="thunder_${TIMESTAMP}.log"
 bash start.sh > "$LOG_FILE" 2>&1 &
+start_pid=$!
 cd "../"
 
-echo "Waiting $waiting_time seconds..."
-sleep $waiting_time
+echo "Waiting up to $waiting_time seconds for Thunder to listen on port $port..."
+waited=0
+while ((waited < waiting_time)); do
+    if ! port_is_free; then
+        break
+    fi
+    # start.sh exiting early means the server failed to come up at all.
+    if ! kill -0 "$start_pid" 2>/dev/null && port_is_free; then
+        break
+    fi
+    sleep 1
+    ((waited++))
+done
+
+if port_is_free; then
+    echo "ERROR: Thunder is not listening on port $port after ${waited}s."
+    echo "--- tail of $carbon_home/$LOG_FILE ---"
+    tail -n 30 "$carbon_home/$LOG_FILE" 2>/dev/null || echo "(no log file)"
+    exit 1
+fi
+
+echo "Thunder is listening on port $port after ${waited}s; settling for ${settle_time}s..."
+sleep $settle_time
 
 echo "Finished starting Thunder..."


### PR DESCRIPTION
`restart-thunder.sh` has never restarted Thunder. It contains no kill step, so every per-phase restart attempt died on the port already being held, and because the start is backgrounded and its exit status never checked, the pipeline reported success and carried on. A single Thunder process has been serving every phase of every run.

The evidence is in the per-phase logs that `after_execute_test_scenario()` already collects. In build 354, each of the nine phases produced a 232-byte log containing:

```
❌ Port 8090 is already in use
   ThunderID server cannot start because another process is using port 8090
```

Meanwhile one log, `wso2thunder-thunder_20260811_122701.log`, grew monotonically across the run because the cleanup targeted `repository/logs/`, which Thunder does not use:

| Phase | Size of the surviving log |
|---|---|
| 00 client credentials, 50 users | 92 MB |
| 00 client credentials, 500 users | 273 MB |
| 01 authorization code, 50 users | 280 MB |
| 01 authorization code, 500 users | 383 MB |
| 02 authenticate with credentials, 500 users | 672 MB |

That is roughly 300 bytes per HTTP request, about 90 KB/s sustained, on a node with 512 MB of RAM and 34 MB free.

## Why it matters

Every benchmark in this repository has measured a server still carrying the previous phases' in-memory state, connection pools and log file. The ordering makes this worst for the authorization code scenario, which runs third, after roughly 45 minutes of CPU-saturating load and with a log file already past 280 MB. It is also the only scenario driven below saturation, so it is the only one whose latency reflects how the server actually feels rather than being pinned by concurrency divided by throughput.

That is the leading explanation for the instability in that metric. Four runs of the identical `v1.0.0-beta2` pack produced end-to-end authorization code latency at 500 users of 268.9, 175.1, 338.3 and 127.1 ms, a 2.7 fold spread, against 116.5 and 149.0 ms for the two `v1.0.0-beta` runs. A two run comparison across that spread cannot support a conclusion about a version difference.

## Approach

| Change | Why |
|---|---|
| `stop_thunder()`: resolve the PIDs holding the listen socket, `TERM`, poll up to 20s, escalate to `KILL`, return non-zero if the port is still held | The missing step. Without it the restart is a no-op |
| PID lookup via `ss -lptnH`, falling back to `lsof -ti` then `pgrep -f` | `iproute2` is present on the perf AMIs; the fallbacks keep it portable |
| Replace `sleep $waiting_time` with a poll for the port to listen, bounded by `-w`, then a short settle | A blind sleep cannot tell a started server from a failed one. Also breaks early if `start.sh` exits |
| Exit non-zero with the log tail when the port never opens | `run-performance-tests.sh` and `perf-test-thunder.sh` are both `bash -e` and call this unguarded, so the run now aborts instead of publishing invalid results |
| Delete top level `thunder_*.log`, keeping `thunder_setup_*.log` | The old path did not match the real log. Logs are scp'd off the node before this runs, so each phase's log is already preserved in its own report directory |
| New `-p <port>`, default 8090 | Matches `server.port` in `single-node/setup/resources/deployment.yaml`. The only caller passes no arguments, so no caller change was needed |

## Verification

Run 358 on this branch, full 50/200/500 run:

| Check | Build 354 (before) | Build 358 (after) |
|---|---|---|
| Phases | 9 | 9 |
| `Stopping Thunder (PIDs: ...)` | absent | 9 |
| Clean stops on `TERM`, no `KILL` needed | n/a | 9 |
| `Thunder is listening on port 8090` | absent | 9 |
| `Port 8090 is already in use` | 9 | 0 |
| Start failures | silent | 0 |
| Full results artifact | 506 MB | 155 MB |

The decisive detail is the PID stopped at each phase: 5123, 5232, 5806, 6379, 6950, 7544, 8112, 8679, 9250. Nine distinct, increasing PIDs means a genuinely new process served each phase and the previous one was actually terminated. Every stop completed in 0s and the port was listening again within 1s.

Before this went near a full run, the script was exercised against a stand-in server for the four paths that matter: a cold start, a restart with a server already running (PID confirmed to change), a `start.sh` that cannot bind (exit 1 plus log tail, and a `bash -e` caller aborting), and a process that ignores `TERM` (escalation to `KILL` after the grace period, then a clean start).

## Results

Build 358 measured 141.7 ms end-to-end at 500 users with a step p95 sum of 357 ms, which sits inside the range of the two `v1.0.0-beta` runs on both figures. That is consistent with the earlier gap having been an artefact of accumulated state rather than a code regression, but it is one run and does not by itself show that the variance has collapsed. Repeats are worth having before drawing a conclusion about `v1.0.0-beta2`.

## Not in this PR

- The runtime database cleanup in `before_execute_test_scenario` is still commented out, so `runtime_transient` and `runtime_persistent` continue to accumulate across a whole run. Note that the referenced `clean_database` function does not exist anywhere in the repo, so that line cannot simply be uncommented. Follow-up.
- `update-thunder-conf.sh` starts Thunder with the same backgrounded and unchecked pattern for the initial start. Less harmful, since nothing holds the port yet, but a failed first start would still be silent.
- `long-run-sampler.sh` queries a database named `runtimedb` for tables such as `AUTHORIZATION_CODE` and `FLOW_CONTEXT`. Neither the database nor those tables exist in this schema, which uses `runtime_transient` and `runtime_persistent` with a single partitioned `RUNTIME_STORE`. Its RDS section has been failing silently into a `WARN` line.

Related: #86 addresses per-run server state on the Azure path. This is the equivalent problem on the VM path, though the mechanism and fix are unrelated.

The benchmark results the pipeline published from this branch's own validation runs, builds 357 and 358, are deliberately kept out of this PR so it changes one file only. They are preserved on `restart-issue-benchmarks` if they are wanted separately.
